### PR TITLE
fix: render bytewise-op bytes correctly in --explain (#31)

### DIFF
--- a/hashcat_rosetta/cli.py
+++ b/hashcat_rosetta/cli.py
@@ -56,6 +56,26 @@ def _cap(prev: str, new: str) -> str:
     return new if len(new) < _RP_PASSWORD_SIZE else prev
 
 
+def _escape_bytes(text: str) -> str:
+    r"""Render raw byte values (control chars and 0x80-0xFF) as ``\xNN``.
+
+    ``explain_rule`` builds transformed words from code points 0-255 (one code
+    point per byte). Emitting those directly would UTF-8-encode code points
+    0x80-0xFF into multibyte sequences, misrepresenting hashcat's single-byte
+    output (e.g. 0x99 -> ``c2 99``). Escape any code point below 0x100 that
+    isn't printable ASCII; genuine Unicode in the descriptions (such as the
+    U+2192 ``->`` arrow) is >= 0x100 and left intact.
+    """
+    out = []
+    for ch in text:
+        o = ord(ch)
+        if o < 0x100 and not (0x20 <= o <= 0x7E):
+            out.append(f"\\x{o:02x}")
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
 def explain_rule(rule_str: str, baseword: str = "password") -> list | None:
     """Explain what a hashcat rule does with examples."""
     if not rule_str:
@@ -325,7 +345,9 @@ def explain_rule(rule_str: str, baseword: str = "password") -> list | None:
                 pos = _hashcat_pos(pos_char)
                 prev = current
                 if pos < len(current):
-                    current = current[:pos] + chr(ord(current[pos]) + 1) + current[pos + 1 :]
+                    current = (
+                        current[:pos] + chr((ord(current[pos]) + 1) & 0xFF) + current[pos + 1 :]
+                    )
                 steps.append(f"+{pos_char}: Increment ASCII at pos {pos} → {prev} → {current}")
                 i += 2
             except (ValueError, IndexError):
@@ -338,7 +360,9 @@ def explain_rule(rule_str: str, baseword: str = "password") -> list | None:
                 pos = _hashcat_pos(pos_char)
                 prev = current
                 if pos < len(current):
-                    current = current[:pos] + chr(ord(current[pos]) - 1) + current[pos + 1 :]
+                    current = (
+                        current[:pos] + chr((ord(current[pos]) - 1) & 0xFF) + current[pos + 1 :]
+                    )
                 steps.append(f"-{pos_char}: Decrement ASCII at pos {pos} → {prev} → {current}")
                 i += 2
             except (ValueError, IndexError):
@@ -749,7 +773,7 @@ def main(
                     if explanations:
                         click.echo(f"\nLine {line_number}: {rule_line}")
                         for explanation in explanations:
-                            click.echo(f"  {explanation}")
+                            click.echo(f"  {_escape_bytes(explanation)}")
                     else:
                         click.echo(f"\nLine {line_number}: {rule_line}")
                         click.echo("  [!] Unknown rule or no explanation available")
@@ -761,7 +785,7 @@ def main(
                 click.echo(f"\nRule Explanation: '{explain}' applied to '{baseword}'")
                 click.echo("=" * 70)
                 for explanation in explanations:
-                    click.echo(f"  {explanation}")
+                    click.echo(f"  {_escape_bytes(explanation)}")
                 click.echo("=" * 70)
                 click.echo("\nNote: Each character is a rule operation applied sequentially.")
                 click.echo("      Complex rules combine multiple operations from left to right.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ import json
 import pytest
 from click.testing import CliRunner
 
-from hashcat_rosetta.cli import explain_rule, main
+from hashcat_rosetta.cli import _escape_bytes, explain_rule, main
 
 
 # Shared fixtures
@@ -371,3 +371,60 @@ class TestExplainRuleEdgeCases:
         result = explain_rule("T0", "hello")
         assert result is not None
         assert "Hello" in result[0]
+
+
+class TestEscapeBytesHelper:
+    """_escape_bytes renders raw bytes for display without touching genuine
+    Unicode (issue #31)."""
+
+    def test_high_byte_escaped(self):
+        assert _escape_bytes("\x99ello0") == "\\x99ello0"
+
+    def test_control_byte_escaped(self):
+        assert _escape_bytes("\x00abc") == "\\x00abc"
+        assert _escape_bytes("\x1f") == "\\x1f"
+
+    def test_printable_ascii_unchanged(self):
+        assert _escape_bytes("hello0!") == "hello0!"
+
+    def test_unicode_above_ff_unchanged(self):
+        # The '→' arrow (U+2192) is >= 0x100 and must be left intact.
+        assert _escape_bytes("a → b") == "a → b"
+
+
+class TestExplainBytewiseWrap:
+    """explain_rule keeps raw byte values internally (so the verify harness can
+    compare against hashcat) and wraps +/- mod 256 like hashcat (issue #31)."""
+
+    def test_explain_returns_raw_high_byte(self):
+        # B01 on 'hello0': 0x68 + 0x31 = 0x99. explain_rule returns the raw code
+        # point; escaping for display happens only in the CLI layer.
+        steps = explain_rule("B01", "hello0")
+        assert steps is not None
+        assert "\x99ello0" in steps[-1]
+
+    def test_increment_wraps_mod_256(self):
+        # '+0' on byte 0xff wraps to 0x00 (verified against hashcat).
+        steps = explain_rule("+0", "\xffabc")
+        assert steps is not None
+        assert "\x00abc" in steps[-1]
+
+    def test_decrement_wraps_mod_256_no_crash(self):
+        # '-0' on byte 0x00 wraps to 0xff (verified against hashcat). Previously
+        # chr(-1) raised ValueError and the step was silently dropped.
+        steps = explain_rule("-0", "\x00abc")
+        assert steps is not None
+        assert "\xffabc" in steps[-1]
+
+
+class TestExplainCliByteRendering:
+    """The --explain CLI output must render high bytes as \\xNN, never as a
+    UTF-8-mis-encoded multibyte sequence (issue #31)."""
+
+    def test_cli_explain_escapes_high_byte(self, runner):
+        result = runner.invoke(main, ["--explain", "B01", "--baseword", "hello0"])
+        assert result.exit_code == 0
+        assert "\\x99ello0" in result.output
+        # The raw U+0099 code point (which would UTF-8-encode to c2 99) must not
+        # appear in the user-facing output.
+        assert "\x99" not in result.output


### PR DESCRIPTION
Fixes #31. Stacked on #30 (base = `fix/tokenizer-opcode-arity`) so it inherits the green CI/oracle setup; retarget to `main` after #30 merges.

## Problem
`explain_rule`'s bytewise ops (`+ - L R B`) build transformed words from code points 0–255. Printing them directly UTF-8-encodes code points `0x80–0xFF` into multibyte sequences, misrepresenting hashcat's single-byte output:

```
B01 on 'hello0' → hashcat: 99 65 6c 6c 6f 30 ('\x99ello0')
                     ours: c2 99 65 6c 6c 6f 30  (U+0099 → c2 99)
```

Also `+`/`-` lacked hashcat's mod-256 wrap, and `-` at byte `0x00` raised `ValueError` (`chr(-1)`), silently dropping the step.

## Fix
- `& 0xFF` on `+` and `-` so they wrap like hashcat (verified: `+0` on `0xff`→`0x00`; `-0` on `0x00`→`0xff`); removes the `-` crash path.
- New `_escape_bytes()` applied **only at the `--explain` CLI print sites**, rendering raw bytes (control chars and `0x80–0xFF`) as `\xNN` while leaving genuine Unicode (the `→` arrow) intact.

## Why escaping is display-only
`_verify`/the opcode sweep read `explain_rule`'s return value and compare it to hashcat's raw bytes. `explain_rule` therefore keeps returning **raw** code points; only the CLI output is escaped. (An earlier attempt that escaped inside `explain_rule` broke the `hashcat_vs_explain` integration test, because control chars are `isascii()` and got compared as `\xNN` literals — fixed by moving the escape to the print layer.)

## Verification
- `uv run pytest` — full suite green, including the `hashcat_vs_explain` integration test.
- ruff + mypy clean.
- `uv run hashcat-rosetta --explain "B01" --baseword hello0` now prints `→ \x99ello0` (no `c2 99`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)