### PR TITLE
fix: match hashcat exactly for hex escapes, 3NX, and ASCII-only casing

### DIFF
--- a/hashcat_rosetta/_verify.py
+++ b/hashcat_rosetta/_verify.py
@@ -186,6 +186,12 @@ _POS_2ARG_FIRST: set[str] = set("io=*xOvB")
 # table like O omit-count and x extract-length). Hashcat validates them
 # identically, so they get the same arg-encoding check.
 _POS_2ARG_SECOND: set[str] = set("*Ox")
+# Opcodes whose first arg uses the position ENCODING (0-9/A-Z) — hashcat
+# rejects any other encoding — but whose value is NOT a word position, so it is
+# never out-of-bounds (e.g. 3NX's N is an occurrence index; N beyond the number
+# of separators is a silent no-op, not a rejection). These get the invalid-
+# encoding check but NOT the OOB check.
+_POS_2ARG_FIRST_ENCODING_ONLY: set[str] = set("3")
 
 
 def _hex_value(c: str) -> int | None:
@@ -308,7 +314,11 @@ def _has_invalid_position_arg(rule_str: str) -> bool:
         args = rule_str[i + 1 : i + 1 + arity]
         if c in _POS_1ARG_FIRST and arity >= 1 and _hex_value(args[0]) is None:
             return True
-        if c in _POS_2ARG_FIRST and arity >= 2 and _hex_value(args[0]) is None:
+        if (
+            (c in _POS_2ARG_FIRST or c in _POS_2ARG_FIRST_ENCODING_ONLY)
+            and arity >= 2
+            and _hex_value(args[0]) is None
+        ):
             return True
         if c in _POS_2ARG_SECOND and arity >= 2 and _hex_value(args[1]) is None:
             return True

--- a/hashcat_rosetta/_verify.py
+++ b/hashcat_rosetta/_verify.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from hashcat_rosetta.cli import explain_rule
-from hashcat_rosetta.parser import RuleParser
+from hashcat_rosetta.parser import RuleParser, decode_hex_escapes
 
 VerifyStatus = Literal[
     "match",
@@ -77,7 +77,7 @@ def decide_rejection_status(
 
 # Mirrors verify_rules.py - keep in sync if hashcat adds opcodes.
 _THREE_ARG_OPCODES: set[str] = set("X")
-_TWO_ARG_OPCODES: set[str] = set("soix*=vOB")
+_TWO_ARG_OPCODES: set[str] = set("soix*=vOB3")
 _ONE_ARG_OPCODES: set[str] = set("TDpyYezZ^$@!><'+-.,%LR()e")
 _ZERO_ARG_OPCODES: set[str] = set(":culdrt[]{}fkKqCEMa")
 _ALL_KNOWN_OPCODES = _THREE_ARG_OPCODES | _TWO_ARG_OPCODES | _ONE_ARG_OPCODES | _ZERO_ARG_OPCODES
@@ -151,6 +151,7 @@ _DEFAULT_IMPLEMENTED: set[str] = {
     ")",
     "v",
     "e",
+    "3",
 }
 
 
@@ -337,8 +338,12 @@ def _has_truncated_opcode(rule_str: str) -> bool:
         else:
             i += 1
             continue
+        # A space is a valid literal argument (e.g. decoded from \x20, or
+        # `$ ` appending a space), NOT a separator here — hashcat consumes the
+        # next byte as the arg regardless. Only running off the end of the
+        # string is genuine truncation.
         for k in range(1, args_needed + 1):
-            if i + k >= n or rule_str[i + k] == " ":
+            if i + k >= n:
                 return True
         i += args_needed + 1
     return False
@@ -437,7 +442,13 @@ def verify_rule(rule: str, baseword: str, implemented: set[str] | None = None) -
             baseword=baseword,
         )
 
-    unimpl = _unimplemented_opcodes(rule, implemented)
+    # hashcat decodes \xNN byte escapes before parsing the rule; decode first
+    # so opcode/position analysis sees the same characters. explain_rule and
+    # _hashcat_output are given the ORIGINAL rule (each decodes once itself /
+    # internally) to avoid a non-idempotent double decode.
+    decoded = decode_hex_escapes(rule)
+
+    unimpl = _unimplemented_opcodes(decoded, implemented)
     if unimpl:
         return VerifyResult(
             status="skipped_unimpl",
@@ -446,16 +457,16 @@ def verify_rule(rule: str, baseword: str, implemented: set[str] | None = None) -
             unimpl_opcodes=unimpl,
         )
 
-    extracted_opcodes = _extract_opcodes(rule)
+    extracted_opcodes = _extract_opcodes(decoded)
     unsupported = any(
         op in _HASHCAT_STDOUT_UNSUPPORTED or op not in _ALL_KNOWN_OPCODES
         for op in extracted_opcodes
     )
     if (
         unsupported
-        or _has_truncated_opcode(rule)
-        or _has_oob_position(rule, baseword)
-        or _has_invalid_position_arg(rule)
+        or _has_truncated_opcode(decoded)
+        or _has_oob_position(decoded, baseword)
+        or _has_invalid_position_arg(decoded)
     ):
         return VerifyResult(
             status="skipped_hashcat_unsupported",

--- a/hashcat_rosetta/cli.py
+++ b/hashcat_rosetta/cli.py
@@ -9,6 +9,7 @@ import click
 
 from .debug_analyzer import DebugAnalyzer
 from .formatting import display_rule_opcodes_summary
+from .parser import decode_hex_escapes
 
 _BANNER = r"""
  _   _           _               _   ____                _   _
@@ -76,20 +77,47 @@ def _escape_bytes(text: str) -> str:
     return "".join(out)
 
 
+def _ascii_lower(s: str) -> str:
+    """Lowercase only ASCII A-Z, like hashcat (leaves 0x80-0xFF untouched)."""
+    return "".join(chr(ord(c) + 0x20) if "A" <= c <= "Z" else c for c in s)
+
+
+def _ascii_upper(s: str) -> str:
+    """Uppercase only ASCII a-z, like hashcat."""
+    return "".join(chr(ord(c) - 0x20) if "a" <= c <= "z" else c for c in s)
+
+
+def _ascii_swapcase(s: str) -> str:
+    """Toggle case of only ASCII letters, like hashcat."""
+    out = []
+    for c in s:
+        if "A" <= c <= "Z":
+            out.append(chr(ord(c) + 0x20))
+        elif "a" <= c <= "z":
+            out.append(chr(ord(c) - 0x20))
+        else:
+            out.append(c)
+    return "".join(out)
+
+
 def explain_rule(rule_str: str, baseword: str = "password") -> list | None:
     """Explain what a hashcat rule does with examples."""
     if not rule_str:
         return None
 
+    # hashcat decodes \xNN byte escapes before applying the rule; do the same
+    # so the simulated result matches hashcat (e.g. s\x20_ substitutes a space).
+    rule_str = decode_hex_escapes(rule_str)
+
     # Rule explanations
     rule_map = {
         ":": ("No-op", lambda x: x),
-        "c": ("Capitalize", lambda x: x[0].upper() + x[1:].lower() if x else x),
-        "u": ("Uppercase all", lambda x: x.upper()),
-        "l": ("Lowercase all", lambda x: x.lower()),
+        "c": ("Capitalize", lambda x: _ascii_upper(x[0]) + _ascii_lower(x[1:]) if x else x),
+        "u": ("Uppercase all", lambda x: _ascii_upper(x)),
+        "l": ("Lowercase all", lambda x: _ascii_lower(x)),
         "d": ("Duplicate word", lambda x: x + x),
         "r": ("Reverse", lambda x: x[::-1]),
-        "t": ("Toggle case all", lambda x: "".join(c.swapcase() for c in x)),
+        "t": ("Toggle case all", lambda x: _ascii_swapcase(x)),
         "[": ("Remove first", lambda x: x[1:] if x else x),
         "]": ("Remove last", lambda x: x[:-1] if x else x),
         "{": ("Rotate left", lambda x: x[1:] + x[0] if x else x),
@@ -100,12 +128,15 @@ def explain_rule(rule_str: str, baseword: str = "password") -> list | None:
         "q": ("Duplicate every char", lambda x: "".join(c + c for c in x)),
         "C": (
             "Invert capitalize",
-            lambda x: x[0].lower() + x[1:].upper() if x else x,
+            lambda x: _ascii_lower(x[0]) + _ascii_upper(x[1:]) if x else x,
         ),
         "E": (
             "Title case",
             lambda x: (
-                " ".join(w[0].upper() + w[1:].lower() if w else w for w in x.lower().split(" "))
+                " ".join(
+                    _ascii_upper(w[0]) + _ascii_lower(w[1:]) if w else w
+                    for w in _ascii_lower(x).split(" ")
+                )
                 if x
                 else x
             ),
@@ -199,7 +230,7 @@ def explain_rule(rule_str: str, baseword: str = "password") -> list | None:
                 pos = _hashcat_pos(pos_char)
                 prev = current
                 if pos < len(current):
-                    current = current[:pos] + current[pos].swapcase() + current[pos + 1 :]
+                    current = current[:pos] + _ascii_swapcase(current[pos]) + current[pos + 1 :]
                 steps.append(f"T{pos_char}: Toggle case at pos {pos} → {prev} → {current}")
                 i += 2
             except (ValueError, IndexError):
@@ -606,13 +637,13 @@ def explain_rule(rule_str: str, baseword: str = "password") -> list | None:
             sep = rule_str[i + 1]
             prev = current
             orig = current  # preserve original for separator matching
-            lowered = current.lower()
+            lowered = _ascii_lower(current)
             chars = list(lowered)
             if chars:
-                chars[0] = chars[0].upper()
+                chars[0] = _ascii_upper(chars[0])
             for idx in range(1, len(chars)):
                 if orig[idx - 1] == sep:
-                    chars[idx] = chars[idx].upper()
+                    chars[idx] = _ascii_upper(chars[idx])
             current = "".join(chars)
             steps.append(f"e{sep}: Title-case with separator '{sep}' → {prev} → {current}")
             i += 2
@@ -634,6 +665,36 @@ def explain_rule(rule_str: str, baseword: str = "password") -> list | None:
                 steps.append(
                     f"B{pos_char}{add_char}: Add ord('{add_char}')={ord(add_char)} "
                     f"to byte at pos {pos} → {prev} → {current}"
+                )
+                i += 3
+            except (ValueError, IndexError):
+                i += 1
+
+        elif char == "3" and i + 2 < len(rule_str):
+            # 3NX: toggle the case of the character immediately after the Nth
+            # (0-indexed) occurrence of separator char X. If there is no Nth
+            # occurrence (or no char after it) the word is unchanged. Verified
+            # against hashcat: '30s' password -> pasSword, '31s' -> passWord.
+            n_char = rule_str[i + 1]
+            sep = rule_str[i + 2]
+            try:
+                n = _hashcat_pos(n_char)
+                prev = current
+                idx = -1
+                count = 0
+                for k, ch2 in enumerate(current):
+                    if ch2 == sep:
+                        if count == n:
+                            idx = k
+                            break
+                        count += 1
+                if idx != -1 and idx + 1 < len(current):
+                    current = (
+                        current[: idx + 1] + _ascii_swapcase(current[idx + 1]) + current[idx + 2 :]
+                    )
+                steps.append(
+                    f"3{n_char}{sep}: Toggle case after occurrence {n} of "
+                    f"'{sep}' → {prev} → {current}"
                 )
                 i += 3
             except (ValueError, IndexError):

--- a/hashcat_rosetta/parser.py
+++ b/hashcat_rosetta/parser.py
@@ -1,8 +1,23 @@
 """Parser module for hashcat rules and debug files."""
 
 import logging
+import re
 
 logger = logging.getLogger(__name__)
+
+# hashcat decodes ``\xNN`` byte escapes in rule strings (e.g. ``s\x20_``
+# substitutes a literal space). Decode them to the single byte they denote so
+# downstream tokenizing/simulation sees the same characters hashcat does.
+_HEX_ESCAPE_RE = re.compile(r"\\x([0-9A-Fa-f]{2})")
+
+
+def decode_hex_escapes(rule_str: str) -> str:
+    r"""Replace ``\xNN`` hex escapes with the single byte (code point 0-255).
+
+    Mirrors hashcat's rule parser. A backslash not followed by ``x`` and two
+    hex digits is left untouched (it is a literal character in hashcat).
+    """
+    return _HEX_ESCAPE_RE.sub(lambda m: chr(int(m.group(1), 16)), rule_str)
 
 
 # Sentinel wordlist values hashcat emits when there is no real dict path.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -373,6 +373,94 @@ class TestExplainRuleEdgeCases:
         assert "Hello" in result[0]
 
 
+class TestAsciiOnlyCasing:
+    """hashcat case ops (l u c C t E e T 3) only affect ASCII A-Z/a-z; they
+    leave high bytes (0x80-0xFF) untouched. Python str casing does not, which
+    diverged after L/R/B/+/- produced accented bytes (issue: BARRAGE 'L6 l')."""
+
+    def _f(self, rule, bw):
+        s = explain_rule(rule, bw)
+        assert s is not None
+        # strip only the ASCII spaces around the arrow, not high bytes like
+        # 0xA0 (NBSP) which str.strip() would wrongly remove.
+        return s[-1].split("→")[-1].strip(" ")
+
+    def test_lower_leaves_high_byte(self):
+        assert self._f("l", "\xc8") == "\xc8"  # 'È' stays (python would give è)
+
+    def test_upper_leaves_high_byte(self):
+        assert self._f("u", "\xe8") == "\xe8"  # 'è' stays
+
+    def test_toggle_leaves_high_byte(self):
+        assert self._f("t", "\xc8") == "\xc8"
+
+    def test_L_then_lower_matches_hashcat(self):
+        # 'L6 l' on 'password': L shifts byte 6 ('r'=0x72<<1=0xe4)... use the
+        # observed repro pattern; the high byte must not be case-mapped.
+        out = self._f("L0 l", "Password")  # L0: 'P'=0x50<<1=0xa0; l leaves 0xa0
+        assert out == "\xa0assword"
+
+    def test_ascii_casing_unchanged(self):
+        assert self._f("u", "abc") == "ABC"
+        assert self._f("l", "ABC") == "abc"
+        assert self._f("c", "hELLO") == "Hello"
+        assert self._f("t", "aBc") == "AbC"
+
+
+class TestExplainToggleAtSep:
+    """3NX: toggle case of the char after the Nth (0-indexed) occurrence of
+    separator X. Values verified against hashcat --stdout."""
+
+    def _final(self, rule, bw):
+        steps = explain_rule(rule, bw)
+        assert steps is not None, f"{rule} returned None"
+        return steps[-1].split("→")[-1].strip()
+
+    def test_3_first_occurrence(self):
+        assert self._final("30s", "password") == "pasSword"
+
+    def test_3_second_occurrence(self):
+        assert self._final("31s", "password") == "passWord"
+
+    def test_3_missing_occurrence_noop(self):
+        assert self._final("32s", "password") == "password"
+
+    def test_3_nonletter_after_sep_noop(self):
+        assert self._final("30.", "a.1b") == "a.1b"
+
+    def test_3_letter_after_sep(self):
+        assert self._final("30.", "a.b") == "a.B"
+
+
+class TestHexEscapeDecoding:
+    """hashcat decodes \\xNN byte escapes in rules; explain_rule must too, so
+    its output matches hashcat for BARRAGE rules that use them."""
+
+    def test_substitute_space_via_hex_escape(self):
+        # s\x20X = substitute space -> X. hashcat 'a b' -> 'aXb'.
+        steps = explain_rule("s\\x20X", "a b")
+        assert steps is not None
+        assert steps[-1].split("→")[-1].strip() == "aXb"
+
+    def test_append_hex_escape(self):
+        # $\x41 = append 'A' (0x41). 'ab' -> 'abA'.
+        steps = explain_rule("$\\x41", "ab")
+        assert steps is not None
+        assert steps[-1].split("→")[-1].strip() == "abA"
+
+    def test_hex_escape_not_mistokenized(self):
+        # \x73 = 's'; $\x73 must be "append 's'", not a substitute op.
+        steps = explain_rule("$\\x73", "ab")
+        assert steps is not None
+        assert steps[-1].split("→")[-1].strip() == "abs"
+
+    def test_non_hex_backslash_left_literal(self):
+        # A backslash not forming \xNN is a literal char (append it).
+        steps = explain_rule("$\\", "ab")
+        assert steps is not None
+        assert steps[-1].split("→")[-1].strip() == "ab\\"
+
+
 class TestEscapeBytesHelper:
     """_escape_bytes renders raw bytes for display without touching genuine
     Unicode (issue #31)."""

--- a/tests/test_verify_lib.py
+++ b/tests/test_verify_lib.py
@@ -134,6 +134,18 @@ class TestHashcatUnsupportedOpcodes:
         assert _has_truncated_opcode("u s.")
         assert _has_truncated_opcode("$")
 
+    def test_space_is_a_valid_argument_not_truncation(self) -> None:
+        """A space is a valid literal argument (e.g. decoded from \\x20), not a
+        truncation marker. hashcat accepts '$ ' (append space) and 's _'
+        (substitute space->_); only running off the end is real truncation."""
+        from hashcat_rosetta._verify import _has_truncated_opcode
+
+        assert not _has_truncated_opcode("s _")  # substitute space -> _
+        assert not _has_truncated_opcode("$ ")  # append space
+        assert not _has_truncated_opcode("i0 ")  # insert space at pos 0
+        # trailing opcode still missing its args at end-of-string is truncated
+        assert _has_truncated_opcode("s _ i1")
+
 
 class TestExtractFinal:
     """_extract_final must preserve leading/trailing whitespace in the final

--- a/tests/test_verify_lib.py
+++ b/tests/test_verify_lib.py
@@ -257,6 +257,18 @@ class TestOOBPositionSkip:
         assert _has_oob_position("*01", "cat") is False
         assert _has_oob_position("u $a", "cat") is False
 
+    def test_3_position_encoding_validated_but_not_oob(self) -> None:
+        """3NX's N is a position-ENCODED occurrence index: hashcat rejects an
+        invalid encoding (lowercase 'a') but never rejects it as out-of-bounds
+        (an occurrence index beyond the separators is a silent no-op)."""
+        from hashcat_rosetta._verify import _has_invalid_position_arg, _has_oob_position
+
+        assert _has_invalid_position_arg("3ab") is True  # 'a' is not 0-9/A-Z
+        assert _has_invalid_position_arg("30s") is False
+        assert _has_invalid_position_arg("3Az") is False  # 'A' = position 10
+        # occurrence index far beyond the word is NOT out-of-bounds for '3'
+        assert _has_oob_position("3Zs", "password") is False
+
 
 class TestHexValueHelper:
     def test_digit(self) -> None:


### PR DESCRIPTION
Closes four correctness gaps that made `explain_rule` (and the `_verify` harness) diverge from hashcat. Surfaced and validated by a **full byte-for-byte comparison of all 32,467,184 BARRAGE rules** against `hashcat --stdout`.

## Result
**100.000000% match** on the 32,331,257 oracle-comparable rules (0 mismatches, all 647 chunks byte-equal). Remaining skips are inherent: ~113K hashcat-rejected/malformed, ~23K memory/reject ops `--stdout` can't oracle, and **4** genuinely-unimplemented (down from 48,428).

## Fixes
1. **`\xNN` hex-escape decoding** (`parser.decode_hex_escapes`) — hashcat decodes byte escapes before applying a rule (`s\x20_` = substitute a space). Applied in `explain_rule` and `_verify`'s pre-hashcat classifiers; the original rule still goes to hashcat/`explain_rule` (which decode once) to avoid a non-idempotent double decode. ~572K BARRAGE rules.
2. **`3NX` opcode** — toggle case of the char after the Nth (0-indexed) occurrence of separator `X`; registered in `_verify` arity/implemented sets so the sweep verifies it. ~25K rules.
3. **ASCII-only casing** (`l u c C t E e T 3`) — case-map only ASCII `A-Z`/`a-z`, like hashcat. Python's `str.lower()/upper()/swapcase()` also map Latin-1 accented bytes, which diverged whenever `L`/`R`/`B`/`+`/`-` produced a high byte (e.g. `L6 l`).
4. **`_has_truncated_opcode`** — a space is a valid literal argument (`$ ` appends a space), not a truncation marker; only running off the end of the rule is truncation.

## Verification
- Full 32.4M BARRAGE byte-for-byte sweep: **0 mismatches**.
- Unit tests for each case against hashcat-confirmed values (TDD).
- `uv run pytest` → **778 passed**; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)