### PR TITLE
fix: correct --help entry point name, add fast unit-test CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  unit:
+    # Fast unit-test/lint/type gate — no hashcat binary needed. Complements
+    # accuracy.yml, which is heavier (needs a hashcat oracle) and PR-scoped.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3
+      - name: Sync dependencies
+        run: uv sync
+      - name: Lint
+        run: uv run ruff check hashcat_rosetta/ tests/
+      - name: Format check
+        run: uv run ruff format --check hashcat_rosetta/ tests/
+      - name: Type check
+        run: uv run mypy hashcat_rosetta/
+      - name: Run tests
+        # Integration tests require the hashcat binary; keep this job fast.
+        run: uv run pytest -m "not integration" --cov=hashcat_rosetta tests/

--- a/hashcat_rosetta/cli.py
+++ b/hashcat_rosetta/cli.py
@@ -799,22 +799,22 @@ def main(
     trailing wordlist field, enabling per-wordlist analysis via --wordlists.
 
     Basic usage:
-        rosetta debug.txt
-        rosetta debug.txt --rules --metric frequency
-        rosetta debug.txt --basewords --detail
-        rosetta debug.txt --wordlists --detail
-        rosetta debug.txt --debug-mode 5 --wordlists
-        rosetta debug.txt --export report.json --format json
+        hashcat-rosetta debug.txt
+        hashcat-rosetta debug.txt --rules --metric frequency
+        hashcat-rosetta debug.txt --basewords --detail
+        hashcat-rosetta debug.txt --wordlists --detail
+        hashcat-rosetta debug.txt --debug-mode 5 --wordlists
+        hashcat-rosetta debug.txt --export report.json --format json
 
     Explain rules:
-        rosetta --explain "c"
-        rosetta --explain "i74i81i92iA3"
-        rosetta --explain "cD0sao" --baseword "admin"
-        rosetta --explain "u$!" --baseword "myword"
-        rosetta --explain rules.txt --baseword "admin"
+        hashcat-rosetta --explain "c"
+        hashcat-rosetta --explain "i74i81i92iA3"
+        hashcat-rosetta --explain "cD0sao" --baseword "admin"
+        hashcat-rosetta --explain "u$!" --baseword "myword"
+        hashcat-rosetta --explain rules.txt --baseword "admin"
 
     Analyze rule file opcodes:
-        rosetta rules.txt --analyze-rules
+        hashcat-rosetta rules.txt --analyze-rules
     """
 
     # Show the banner (to stderr so it never pollutes piped/exported stdout)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -259,6 +259,20 @@ class TestErrorPaths:
         assert "Error" in result.output
 
 
+class TestHelpMatchesEntryPoint:
+    """Regression guard: --help examples must use the real registered command name.
+
+    The docstring previously showed `rosetta ...` while pyproject.toml registers
+    `hashcat-rosetta` as the entry point, so copy-pasting --help output failed.
+    """
+
+    def test_help_uses_registered_entry_point_name(self, runner):
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "hashcat-rosetta " in result.output
+        assert "rosetta " not in result.output.replace("hashcat-rosetta ", "")
+
+
 # --- export_to_dict JSON serialization ---
 
 


### PR DESCRIPTION
## Summary
- `--help` examples showed `rosetta ...` but pyproject.toml registers `hashcat-rosetta` as the actual console script, so copy-pasting the examples failed.
- Added a regression test (`TestHelpMatchesEntryPoint`) pinning `--help` output to the real entry-point name.
- Added `.github/workflows/tests.yml`: a fast CI gate (ruff lint/format, mypy, pytest excluding `@pytest.mark.integration`) on every PR/push to main. Previously only the heavy hashcat-dependent `accuracy.yml` ran in CI — the unit test suite never executed, which is how this drifted unnoticed.

## Test plan
- [x] `uv run ruff check` / `ruff format --check`
- [x] `uv run mypy hashcat_rosetta/`
- [x] `uv run pytest -m "not integration" tests/` (64 passed, including new regression test)
- [ ] Confirm new `tests` workflow runs clean on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)