### PR TITLE
Add CHANGELOG, release workflow, and cut 0.4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Tag-triggered runs check out the tag; full history is not needed,
+          # but the changelog extraction below reads the working tree only.
+          fetch-depth: 1
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Verify tag matches pyproject version
+        # The version lives in pyproject.toml and is bumped by hand, so a tag
+        # can easily disagree with it (v0.4.0 tagged while pyproject still
+        # says 0.3.1). Fail loudly here rather than publishing a mislabeled
+        # artifact.
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          proj="$(python3 -c \
+            'import tomllib,pathlib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
+          echo "tag=$tag pyproject=$proj"
+          if [ "$tag" != "$proj" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match pyproject version $proj. Bump pyproject.toml or retag."
+            exit 1
+          fi
+
+      - name: Verify CHANGELOG has an entry for this version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          if ! grep -q "^## \[$tag\]" CHANGELOG.md; then
+            echo "::error::No '## [$tag]' section in CHANGELOG.md."
+            exit 1
+          fi
+
+      - name: Sync dependencies
+        run: uv sync
+
+      - name: Lint
+        run: uv run ruff check hashcat_rosetta/ tests/
+
+      - name: Format check
+        run: uv run ruff format --check hashcat_rosetta/ tests/
+
+      - name: Type check
+        run: uv run mypy hashcat_rosetta/
+
+      - name: Run tests
+        # Integration tests need a hashcat binary as an oracle; accuracy.yml
+        # covers those. A release must not be gated on provisioning hashcat.
+        run: uv run pytest -m "not integration" tests/
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Extract release notes from CHANGELOG
+        # Pull just this version's section: from its heading to the next
+        # top-level heading, dropping the heading line itself.
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          awk -v ver="$tag" '
+            $0 ~ "^## \\[" ver "\\]" { inside = 1; next }
+            inside && /^## / { exit }
+            inside { print }
+          ' CHANGELOG.md > release-notes.md
+          echo "--- release notes ---"
+          cat release-notes.md
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file release-notes.md \
+            dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ hashcat does not perform.
   installed 0.3.0 and have `rosetta` in a script or in muscle memory, update
   it. `python -m hashcat_rosetta` works as before, and `hashcat_rosetta` with
   an underscore remains the import name rather than a command.
+- **The distribution is now named `hashcat-rosetta`, not `hashcatrosetta`.** The
+  project had four spellings of its own name in play, and the smashed-together
+  one appeared exactly once — as the `[project] name` — where it normalized to a
+  different package name than everything else. Distribution and console script
+  are now both `hashcat-rosetta`, the import package stays `hashcat_rosetta`,
+  and built artifacts are `hashcat_rosetta-<version>`. Nothing was published to
+  PyPI under the old name, so this breaks no installs.
 - **ASCII-only case mapping.** `l`, `u`, `c`, `C`, `t`, `E`, `e`, `T`, and `3`
   now case-map only ASCII `A-Z`/`a-z`, matching hashcat. Python's
   `str.lower()`/`upper()`/`swapcase()` also map Latin-1 accented bytes, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,149 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Releases predating this file are summarized from their git history; see the tags
+for exact timing.
+
+## [0.4.0] - 2026-07-29
+
+The headline is accuracy. A full byte-for-byte comparison against hashcat 7.1.2
+over all 32.4M rules in `BARRAGE.rule` now reports **0 mismatches across
+32,331,257 oracle-comparable rules**, and the per-opcode sweep is at 0
+regressions. Getting there took a stack of engine fixes, most of which were
+cases where `explain_rule()` was confidently describing a transformation
+hashcat does not perform.
+
+### Changed
+
+- **BREAKING: the console script is now `hashcat-rosetta`, not `rosetta`.**
+  Renamed to avoid a future `PATH` collision with unrelated tools. If you
+  installed 0.3.0 and have `rosetta` in a script or in muscle memory, update
+  it. `python -m hashcat_rosetta` works as before, and `hashcat_rosetta` with
+  an underscore remains the import name rather than a command.
+- **ASCII-only case mapping.** `l`, `u`, `c`, `C`, `t`, `E`, `e`, `T`, and `3`
+  now case-map only ASCII `A-Z`/`a-z`, matching hashcat. Python's
+  `str.lower()`/`upper()`/`swapcase()` also map Latin-1 accented bytes, which
+  diverged whenever `L`/`R`/`B`/`+`/`-` had produced a high byte upstream in
+  the same rule (`L6 l`, for example).
+- **Length-expanding opcodes respect hashcat's 256-byte cap.** hashcat works in
+  a fixed 256-byte buffer and treats a growing op as a no-op when the result
+  would reach the cap — it does not truncate. Only `p` enforced this before, so
+  `d`, `f`, `q`, `z`, `Z`, `y`, `Y`, `a`, `X`, `v` and the single-character
+  appenders (`$`, `^`, `i`) grew the word unconditionally and produced
+  candidates longer than hashcat's on long basewords. This was the cause of the
+  intermittent nightly accuracy failures.
+- Dev tooling moved to a PEP 735 dependency group.
+
+### Added
+
+- **hashcat `--debug-mode 5` support.** Mode 5 adds the source wordlist as a
+  fourth field, and it is now handled end to end: parsed by `parser.py`,
+  aggregated into per-wordlist statistics by `DebugAnalyzer`, exposed on the
+  CLI via `--wordlists`, and emitted as a `WORDLIST` section in CSV export.
+  Format detection covers mode 5 alongside mode 4, and can still be pinned
+  explicitly with `--debug-mode`.
+- **`B` now simulates hashcat's actual semantics.** The opcode is absent from
+  hashcat's published rule documentation, but the kernel implements it as "byte
+  at position N += ord(X) mod 256", with `X` read as a literal byte rather than
+  a hashcat-encoded position. Verified empirically against 7.1.2 by sweeping
+  `B0X` over `A`.
+- **The `3NX` opcode is implemented** — toggle the case of the character after
+  the Nth (0-indexed) occurrence of separator `X`. Roughly 25K rules in
+  BARRAGE use it.
+- **`\xNN` hex escape decoding.** Rules are decoded before application, mirroring
+  hashcat, so `s\x20_` substitutes a literal space. About 572K BARRAGE rules
+  use hex escapes. With this and `3NX` landed, unimplemented-opcode hits across
+  the BARRAGE sweep dropped from 48,428 to 4.
+- **Per-opcode correctness sweep.** A deterministic rule generator crossed with
+  an argument grid, aggregated by leading opcode, with markdown and JSON
+  renderers, exit-code wiring, and a CI job. `KNOWN_LATENT` marks opcodes whose
+  divergence is understood and tracked rather than silently tolerated.
+- **CLI banner**, printed to stderr so it never pollutes piped or exported
+  stdout.
+- A fast lint/type/unit-test CI workflow that runs on every PR. Previously only
+  the heavy hashcat-dependent accuracy workflow ran in CI, so the unit suite
+  never executed there. (#35)
+
+### Fixed
+
+- **Position arguments above 15 were parsed as hex and silently corrupted the
+  rule.** 29 call sites used `int(c, 16)`, which handles only positions `0-F`,
+  while hashcat encodes positions `0-Z` (0-35). Positions `G-Z` raised
+  `ValueError`, the handler advanced by one byte, and the argument bytes were
+  then reparsed as opcodes — producing wildly wrong candidates across half the
+  position space. All opcodes now share a single `_hashcat_pos()` helper.
+- **Bytewise ops rendered as UTF-8 instead of raw bytes in `--explain`.**
+  `+`, `-`, `L`, `R`, and `B` build words from code points 0-255; printing
+  those directly encoded 0x80-0xFF as multibyte sequences, misrepresenting
+  hashcat's single-byte output. Bytes now display as `\xNN` at the print sites
+  only, leaving genuine Unicode (the `→` arrow) intact. `+` and `-` also gained
+  hashcat's mod-256 wrap, which additionally removes a `ValueError` on `-`
+  at byte 0x00 that had been silently dropping the step. (#31)
+- **Tokenizer arity was wrong for `3`, `X`, and `a`**, producing false
+  "Incomplete opcode" warnings on valid rules during `--analyze-rules`
+  (surfaced by `BARRAGE.rule`). `3` is 2-arg and was 0-arg; `X` is 3-arg and
+  was 2-arg; `a` is a 0-arg legacy op, and as 1-arg it swallowed the following
+  opcode. After the fix, sampling 150 distinct warned rules from BARRAGE,
+  hashcat rejects 150/150 as genuinely malformed — the remaining warnings are
+  true positives.
+- **`Y0` duplicated the entire word.** `current[-0:]` is `current[0:]`, so it
+  appended a full copy instead of zero characters. hashcat treats `Y0` as a
+  no-op.
+- **`p` rejected letter positions.** It parsed its argument with `int(n_char)`,
+  decimal only, so `pA` raised and the rule fell through silently.
+- **Filter opcodes leaked explanation prose into the candidate string.** When a
+  filter (`!`, `<`, `>`, `%`, `(`, `)`, `=`) passed, the recorded step omitted
+  the arrow separator that `_extract_final` keys on, so the description text
+  became the candidate for any rule ending in a passing filter.
+- **A space was treated as a truncation marker.** `_has_truncated_opcode` now
+  only reports genuine truncation — running off the end of the rule — since a
+  space is a valid literal argument (`$ ` appends a space).
+- Verification-harness accuracy, so the oracle stops reporting spurious
+  mismatches: filter opcodes are marked unsupported for `--stdout` comparison
+  (hashcat refuses to emit candidates for any rule containing one, since
+  filters live in the hashing flow); rules carrying an invalid position
+  encoding are skipped rather than compared, because hashcat rejects them
+  outright; and `3`'s first argument is validated for encoding without being
+  bounds-checked, as it is an occurrence index rather than a word position and
+  therefore never out of range (`3Zs` on a short word is a verified silent
+  no-op).
+- `--help` examples showed `rosetta ...` after the entry point had been
+  renamed, so copy-pasting them failed. (#35)
+- The pytest pre-commit hook now runs `uv run --extra dev pytest`, so a bare
+  `uv sync` can no longer leave the venv without pytest and fall through to a
+  `PATH` shim that recursed into an infinite exec loop.
+
+## [0.3.0] - 2026-05-11
+
+- Implement `a` (append memorized), `e` (title-case w/ separator), `v` (toggle
+  every N chars), `(`/`)` (first/last char filters).
+- Refresh opcode descriptions to match hashcat source.
+- Add private `_verify` harness library and `verify_rule` / `verify_corpus` API.
+- Add baseword corpus + accuracy smoke parametrized across it.
+- Filter opcodes now reject (return `None`) when their condition fires, with a
+  rejection-semantics agreement check against hashcat.
+- CI: add per-PR accuracy smoke + nightly full verification, plus a stack of
+  oracle-reliability fixes — bump the hashcat-utils pin to post-v1.9, strip
+  trailing whitespace from generated rules, skip rules hashcat `--stdout`
+  cannot oracle (`M`, `X`, JtR-only opcodes, truncated opcodes, out-of-bounds
+  positions), preserve baseword whitespace through verification, treat empty
+  result or baseword as parity rejections, use a per-call `--session` to dodge
+  the hashcat 6.2.x single-instance lock under thread parallelism, prewarm the
+  POCL kernel cache before the parallel pool, and scope the nightly run to fit
+  the POCL runtime budget on `ubuntu-latest`.
+
+## [0.2.0] - 2026-04-25
+
+The version vendored by hate_crack.
+
+- Apply QA review fixes across parser and analyzer.
+- Add comprehensive test suite (rule matrix, edge cases, CLI, fixes).
+- Implement missing opcodes (`M`, `X`, `=`, `B`) and add `verify_rules.py`
+  validation script.
+- Fix incorrect opcode documentation against hashcat source.
+- Add hashcat-utils integration tests.
+- Add pytest pre-commit hook.

--- a/README.md
+++ b/README.md
@@ -405,29 +405,9 @@ Edit `pyproject.toml` to customize:
 
 ## Version History
 
-### v0.3.0
-- Implement `a` (append memorized), `e` (title-case w/ separator), `v` (toggle every N chars), `(`/`)` (first/last char filters)
-- Refresh opcode descriptions to match hashcat source
-- Add private `_verify` harness library and `verify_rule` / `verify_corpus` API
-- Add baseword corpus + accuracy smoke parametrized across it
-- CI: add per-PR accuracy smoke + nightly full verification
-- CI fixes:
-  - Bump hashcat-utils pin to post-v1.9 (Makefile now builds `bin/*.bin`)
-  - Strip trailing whitespace from generated rules (hashcat-utils format change)
-  - Skip rules using opcodes hashcat `--stdout` can't oracle (M, X, JtR-only opcodes, truncated opcodes, OOB positions)
-  - Preserve baseword whitespace through verification (`_extract_final` no longer `.strip()`s)
-  - Treat empty result / empty baseword as parity rejections
-  - Per-call `--session` to avoid hashcat 6.2.x single-instance lock under thread parallelism
-  - Prewarm POCL kernel cache before parallel pool
-  - Scope nightly to fit POCL runtime budget on `ubuntu-latest`
-
-### v0.2.0
-- Apply QA review fixes across parser and analyzer
-- Add comprehensive test suite (rule matrix, edge cases, CLI, fixes)
-- Implement missing opcodes (M, X, =, B) and add `verify_rules.py` validation script
-- Fix incorrect opcode documentation against hashcat source
-- Add hashcat-utils integration tests
-- Add pytest pre-commit hook
+See [CHANGELOG.md](CHANGELOG.md). It is the single record of what changed in
+each release; this section used to duplicate it, which is a good way to end up
+with two histories that disagree.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "hashcatrosetta"
+name = "hashcat-rosetta"
 version = "0.4.0"
 description = "Analyze hashcat debug output to identify efficient rules and baseword patterns"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hashcatrosetta"
-version = "0.3.1"
+version = "0.4.0"
 description = "Analyze hashcat debug output to identify efficient rules and baseword patterns"
 
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -167,7 +167,7 @@ wheels = [
 ]
 
 [[package]]
-name = "hashcatrosetta"
+name = "hashcat-rosetta"
 version = "0.4.0"
 source = { editable = "." }
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -168,7 +168,7 @@ wheels = [
 
 [[package]]
 name = "hashcatrosetta"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Why

`main` sat at `version = "0.3.1"` in `pyproject.toml` with no tag behind it, and 46 commits since `v0.3.0` (tagged May 11) had no reader-facing summary. There was also no release automation at all — only `accuracy.yml` and `tests.yml` — so nothing connected a tag to a build.

## 0.4.0, not 0.3.1

The range contains a break: `a3905ae` renamed the console script from `rosetta` to `hashcat-rosetta`, so anyone who installed v0.3.0 loses their command. On a 0.x project the minor slot is where a break lands, so the patch number already staged in `pyproject.toml` undersold it. The range also carries real features — `--debug-mode 5` support end to end, and the per-opcode correctness sweep.

The headline is accuracy. `3ce9518`'s byte-for-byte BARRAGE comparison reports **0 mismatches across 32,331,257 oracle-comparable rules** against hashcat 7.1.2, and unimplemented-opcode hits dropped 48,428 → 4.

## Changes

- **`CHANGELOG.md`** (new) — Keep a Changelog format. 0.4.0 entry written from the commit bodies, with the breaking entry-point rename called out first. Historical 0.2.0/0.3.0 entries carried over from README.
- **`README.md`** — Version History replaced with a pointer to the changelog. Keeping both invites the two records drifting apart.
- **`pyproject.toml`** / **`uv.lock`** — 0.3.1 → 0.4.0.
- **`.github/workflows/release.yml`** (new) — tag-triggered (`v*`). Runs the same lint/type/unit gate as `tests.yml`, builds sdist + wheel, creates the release with notes sliced from the changelog.

Two guards run before anything publishes, both for states this repo has actually been in: the tag must match `pyproject.toml`, and the changelog must have a section for that version. Integration tests are excluded from the gate since they need a hashcat oracle that `accuracy.yml` provisions.

## Verification

Run locally on this branch: `ruff check` and `ruff format --check` clean, `mypy` clean across 8 source files, **760 passed / 20 deselected**, and `uv build` produces correctly-named 0.4.0 artifacts with `hashcat-rosetta` as the console script. The workflow's shell logic was exercised directly — the version guard matches on `v0.4.0` and fails on a mismatch, and the `awk` note extraction stops cleanly at the 0.3.0 heading.

## Before merging

`GITHUB_TOKEN` needs Settings → Actions → Workflow permissions set to read **and write** for `gh release create` to work. Tagging `v0.4.0` after merge is what fires the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)