### PR TITLE
Add natural-language to hcmask generation via --mask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Releases predating this file are summarized from their git history; see the tags
 for exact timing.
 
+## [Unreleased]
+
+### Added
+
+- **Natural language to hcmask generation via `--mask` flag.** Describe a password
+  pattern in English (e.g., `"The word 'Summer' followed by six digits."`) and
+  HashcatRosetta generates one or more candidate hashcat masks using a local Ollama
+  server. Every generated mask is validated deterministically through the mask module
+  before being shown to the user. Configurable via `--ollama-host` and `--model` CLI
+  flags, or the `OLLAMA_HOST` and `OLLAMA_MODEL` environment variables. Output can be
+  written to an `.hcmask` file via `-o`/`--mask-out`. All descriptions and generations
+  remain local to the machine — no cloud API calls are made.
+- **`openai` dependency (>=2.52.0)** for OpenAI-compatible API calls to local Ollama.
+
 ## [0.4.0] - 2026-07-29
 
 The headline is accuracy. A full byte-for-byte comparison against hashcat 7.1.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ The package (`hashcat_rosetta/`) has two analysis paths that share a common pars
 - **`cli.py`** - Single Click command (`main`) with flags for different output modes (`--rules`, `--basewords`, `--wordlists`, `--export`, `--explain`, `--analyze-rules`, `--mask`) plus `--debug-mode {auto,4,5}` to force/auto-detect the debug format (debug-file analysis only, not `--analyze-rules`). `--wordlists` shows top wordlists (mode 5 only; honors `--top`, and `--detail` adds per-wordlist unique basewords/candidates/rules). The `--mask` flag generates masks via `nlmask.generate_masks()`, with `-o`/`--mask-out` writing to a file, and `--model`/`--ollama-host` configuring the LLM endpoint. Also contains `explain_rule()` which simulates rule application step-by-step. Entry point registered as `hashcat-rosetta` in pyproject.toml.
 - **`scripts/sweep_opcodes.py`** - Systematic per-opcode correctness sweep. Generates ~230 rules covering every opcode in `_DEFAULT_IMPLEMENTED` against a canonical arg grid, runs them via `_verify.verify_corpus`, and emits a per-opcode matrix to `reports/opcode-sweep.md`. CI job `opcode-sweep` runs this on every PR; mismatches outside `KNOWN_LATENT` fail the build.
 
-The public API exports `RuleAnalyzer`, `RuleParser`, `DebugLogParser`, and `DebugAnalyzer` from `__init__.py`.
+The public API exports `RuleAnalyzer`, `RuleParser`, `DebugLogParser`, `DebugAnalyzer`, plus mask-generation types (`HcmaskLine`, `MaskError`, `parse_hcmask_line`, `keyspace`, `describe`, `format_hcmask_line`, `generate_masks`, `MaskGenerationError`, `MaskSuggestion`) from `__init__.py`.
 
 ## Key Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,9 @@ The package (`hashcat_rosetta/`) has two analysis paths that share a common pars
 - **`debug_analyzer.py`** - `DebugAnalyzer` wraps `DebugLogParser` and computes rule/baseword statistics (frequency, unique basewords per rule, unique candidates), plus per-wordlist statistics for mode-5 files. Accepts an optional `debug_mode=` override. This is the main entry point for debug file analysis.
 - **`analyzer.py`** - `RuleAnalyzer` wraps `RuleParser` for static rule analysis (complexity, efficiency scoring, characteristics extraction). Does not require debug output - analyzes rules in isolation.
 - **`formatting.py`** - Rule opcode descriptions and display formatting for the `analyze-rules` CLI command.
-- **`cli.py`** - Single Click command (`main`) with flags for different output modes (`--rules`, `--basewords`, `--wordlists`, `--export`, `--explain`, `--analyze-rules`) plus `--debug-mode {auto,4,5}` to force/auto-detect the debug format (debug-file analysis only, not `--analyze-rules`). `--wordlists` shows top wordlists (mode 5 only; honors `--top`, and `--detail` adds per-wordlist unique basewords/candidates/rules). Also contains `explain_rule()` which simulates rule application step-by-step. Entry point registered as `hashcat-rosetta` in pyproject.toml.
+- **`mask.py`** - Deterministic hcmask grammar parsing, validation, and keyspace computation. No networking; pure unit-testable functions for `parse_hcmask_line()`, `validate_mask()`, `tokens()`, `keyspace()`, `describe()`, and `format_hcmask_line()`.
+- **`nlmask.py`** - The LLM boundary: calls a local Ollama server via the OpenAI-compatible API to turn a natural-language description into validated hcmask lines. The only module that imports `openai`. Validates all generated masks through `mask.py` before returning them. Raises `MaskGenerationError` on failures.
+- **`cli.py`** - Single Click command (`main`) with flags for different output modes (`--rules`, `--basewords`, `--wordlists`, `--export`, `--explain`, `--analyze-rules`, `--mask`) plus `--debug-mode {auto,4,5}` to force/auto-detect the debug format (debug-file analysis only, not `--analyze-rules`). `--wordlists` shows top wordlists (mode 5 only; honors `--top`, and `--detail` adds per-wordlist unique basewords/candidates/rules). The `--mask` flag generates masks via `nlmask.generate_masks()`, with `-o`/`--mask-out` writing to a file, and `--model`/`--ollama-host` configuring the LLM endpoint. Also contains `explain_rule()` which simulates rule application step-by-step. Entry point registered as `hashcat-rosetta` in pyproject.toml.
 - **`scripts/sweep_opcodes.py`** - Systematic per-opcode correctness sweep. Generates ~230 rules covering every opcode in `_DEFAULT_IMPLEMENTED` against a canonical arg grid, runs them via `_verify.verify_corpus`, and emits a per-opcode matrix to `reports/opcode-sweep.md`. CI job `opcode-sweep` runs this on every PR; mismatches outside `KNOWN_LATENT` fail the build.
 
 The public API exports `RuleAnalyzer`, `RuleParser`, `DebugLogParser`, and `DebugAnalyzer` from `__init__.py`.
@@ -50,7 +52,7 @@ The public API exports `RuleAnalyzer`, `RuleParser`, `DebugLogParser`, and `Debu
 - Build system: hatchling
 - Line length: 100 (configured in pyproject.toml for ruff)
 - Python: >=3.10
-- Dependencies: click
+- Dependencies: click, openai
 - Dev dependencies: pytest, pytest-cov, ruff, mypy, pre-commit (in `[dependency-groups] dev`; installed by default with `uv sync`)
 - Test paths configured to `tests/` directory
 - Tests marked with `@pytest.mark.integration` require the hashcat binary
@@ -67,5 +69,7 @@ hashcat-rosetta FILE --wordlists --detail         # wordlist analysis (mode 5)
 hashcat-rosetta FILE --debug-mode 5 --wordlists   # force mode 5, wordlist analysis
 hashcat-rosetta FILE --export report.json         # export report
 hashcat-rosetta --explain "c$1" --baseword admin  # explain a rule
+hashcat-rosetta --mask "The word 'Summer' followed by six digits."  # generate mask
+hashcat-rosetta --mask "description here" -o masks.hcmask           # save to file
 hashcat-rosetta rules.txt --analyze-rules        # analyze rule file opcodes
 ```

--- a/README.md
+++ b/README.md
@@ -136,8 +136,13 @@ hashcat-rosetta --mask "The word 'Summer' followed by six digits."
 
 Output:
 ```
-Mask: Summer?d?d?d?d?d?d
-Keyspace: 1,000,000
+Mask Suggestions for: 'The word 'Summer' followed by six digits.'
+======================================================================
+
+1. Summer?d?d?d?d?d?d
+   literal "Summer", then 6 × digit → 1,000,000 candidates
+   Keyspace: 1,000,000 candidates
+   Why: matches the literal word followed by a 6-digit number
 ```
 
 Save the generated mask to a file:
@@ -164,8 +169,10 @@ OLLAMA_HOST=http://192.168.1.100:11434 OLLAMA_MODEL=llama2:70b \
 hashcat-rosetta --mask "your description" --ollama-host http://custom.host:11434 --model llama2
 ```
 
-**Security note:** All mask descriptions and generations remain local to your machine.
-There are no cloud API calls — everything runs through your local Ollama instance.
+**Security note:** Mask descriptions are sent only to the Ollama endpoint you configure
+(`localhost` by default, or wherever `--ollama-host`/`OLLAMA_HOST` points) — never to a
+cloud provider. The OpenAI SDK is used purely as an HTTP client against that endpoint;
+no data or API key is ever transmitted to `api.openai.com`.
 
 ### Using the Python API
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,47 @@ hashcat-rosetta --explain "c$1" --baseword admin
 hashcat-rosetta --explain "u$!" --baseword myword
 ```
 
+### Generating Masks with Natural Language
+
+Generate hashcat masks from English descriptions using a local LLM:
+
+```bash
+hashcat-rosetta --mask "The word 'Summer' followed by six digits."
+```
+
+Output:
+```
+Mask: Summer?d?d?d?d?d?d
+Keyspace: 1,000,000
+```
+
+Save the generated mask to a file:
+```bash
+hashcat-rosetta --mask "The word 'Summer' followed by six digits." -o masks.hcmask
+```
+
+Generate masks from other descriptions:
+```bash
+hashcat-rosetta --mask "a capitalized season, two digits, and a special char"
+hashcat-rosetta --mask "year 2020-2025 followed by exclamation or question mark"
+```
+
+The mask generation feature uses a local Ollama server running an OpenAI-compatible chat
+endpoint. By default, it connects to `http://localhost:11434` and uses the model
+`qwen3.6:35b-a3b`. These can be configured via environment variables or CLI flags:
+
+```bash
+# Using environment variables
+OLLAMA_HOST=http://192.168.1.100:11434 OLLAMA_MODEL=llama2:70b \
+  hashcat-rosetta --mask "your description here"
+
+# Using CLI flags (override environment variables)
+hashcat-rosetta --mask "your description" --ollama-host http://custom.host:11434 --model llama2
+```
+
+**Security note:** All mask descriptions and generations remain local to your machine.
+There are no cloud API calls — everything runs through your local Ollama instance.
+
 ### Using the Python API
 
 ```python

--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ Mask Suggestions for: 'The word 'Summer' followed by six digits.'
 
 1. Summer?d?d?d?d?d?d
    literal "Summer", then 6 × digit → 1,000,000 candidates
-   Keyspace: 1,000,000 candidates
    Why: matches the literal word followed by a 6-digit number
 ```
 

--- a/hashcat_rosetta/__init__.py
+++ b/hashcat_rosetta/__init__.py
@@ -4,7 +4,23 @@ __version__ = "0.3.0"
 __author__ = "Justin Bollinger"
 
 from .analyzer import RuleAnalyzer
-from .parser import RuleParser, DebugLogParser
 from .debug_analyzer import DebugAnalyzer
+from .parser import DebugLogParser, RuleParser
+from .mask import HcmaskLine, MaskError, describe, format_hcmask_line, keyspace, parse_hcmask_line
+from .nlmask import MaskGenerationError, MaskSuggestion, generate_masks
 
-__all__ = ["RuleAnalyzer", "RuleParser", "DebugLogParser", "DebugAnalyzer"]
+__all__ = [
+    "RuleAnalyzer",
+    "RuleParser",
+    "DebugLogParser",
+    "DebugAnalyzer",
+    "HcmaskLine",
+    "MaskError",
+    "parse_hcmask_line",
+    "keyspace",
+    "describe",
+    "format_hcmask_line",
+    "generate_masks",
+    "MaskGenerationError",
+    "MaskSuggestion",
+]

--- a/hashcat_rosetta/__init__.py
+++ b/hashcat_rosetta/__init__.py
@@ -6,8 +6,33 @@ __author__ = "Justin Bollinger"
 from .analyzer import RuleAnalyzer
 from .debug_analyzer import DebugAnalyzer
 from .parser import DebugLogParser, RuleParser
+from typing import TYPE_CHECKING, Any
+
 from .mask import HcmaskLine, MaskError, describe, format_hcmask_line, keyspace, parse_hcmask_line
-from .nlmask import MaskGenerationError, MaskSuggestion, generate_masks
+
+if TYPE_CHECKING:  # pragma: no cover - import-time typing only
+    from .nlmask import MaskGenerationError, MaskSuggestion, generate_masks
+
+# Names re-exported from .nlmask. That module imports the ``openai`` SDK,
+# which costs ~450ms, so it is loaded on first attribute access (PEP 562)
+# rather than at ``import hashcat_rosetta`` time.
+_LAZY_NLMASK_EXPORTS = frozenset({"generate_masks", "MaskGenerationError", "MaskSuggestion"})
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve the ``nlmask`` re-exports (PEP 562)."""
+    if name in _LAZY_NLMASK_EXPORTS:
+        from . import nlmask
+
+        value = getattr(nlmask, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | _LAZY_NLMASK_EXPORTS)
+
 
 __all__ = [
     "RuleAnalyzer",

--- a/hashcat_rosetta/cli.py
+++ b/hashcat_rosetta/cli.py
@@ -9,6 +9,8 @@ import click
 
 from .debug_analyzer import DebugAnalyzer
 from .formatting import display_rule_opcodes_summary
+from .mask import describe, format_hcmask_line, keyspace
+from .nlmask import MaskGenerationError, generate_masks
 from .parser import decode_hex_escapes
 
 _BANNER = r"""
@@ -773,6 +775,29 @@ def explain_rule(rule_str: str, baseword: str = "password") -> list | None:
         "(baseword:rule:candidate:wordlist with wordlist attribution)."
     ),
 )
+@click.option(
+    "--mask",
+    type=str,
+    help="Generate an hcmask from an English description via a local Ollama server",
+)
+@click.option(
+    "-o",
+    "--mask-out",
+    type=click.Path(),
+    help="Write generated mask(s) to a .hcmask file (used with --mask)",
+)
+@click.option(
+    "--model",
+    type=str,
+    default=lambda: os.environ.get("OLLAMA_MODEL"),
+    help="Override the model name used for --mask (default: OLLAMA_MODEL env var)",
+)
+@click.option(
+    "--ollama-host",
+    type=str,
+    default=None,
+    help="Override the Ollama host/URL used for --mask (default: OLLAMA_HOST env var)",
+)
 @click.pass_context
 def main(
     ctx,
@@ -790,6 +815,10 @@ def main(
     detail,
     analyze_rules,
     debug_mode,
+    mask,
+    mask_out,
+    model,
+    ollama_host,
 ):
     """Hashcat Rule Efficiency Analyzer - Analyze hashcat debug output files.
 
@@ -815,10 +844,40 @@ def main(
 
     Analyze rule file opcodes:
         hashcat-rosetta rules.txt --analyze-rules
+
+    Generate masks:
+        hashcat-rosetta --mask "The word 'Summer' followed by six digits."
+        hashcat-rosetta --mask "a season and a year" -o seasons.hcmask
     """
 
     # Show the banner (to stderr so it never pollutes piped/exported stdout)
     click.echo(_BANNER, err=True)
+
+    # Handle natural-language mask generation
+    if mask:
+        try:
+            suggestions = generate_masks(mask, model=model, host=ollama_host)
+        except MaskGenerationError as e:
+            click.echo(f"[!] {e}", err=True)
+            sys.exit(1)
+
+        click.echo(f"\nMask Suggestions for: '{mask}'")
+        click.echo("=" * 70)
+        for i, suggestion in enumerate(suggestions, 1):
+            line_str = format_hcmask_line(suggestion.custom_charsets, suggestion.mask)
+            click.echo(f"\n{i}. {line_str}")
+            click.echo(f"   {describe(suggestion.line)}")
+            click.echo(f"   Keyspace: {keyspace(suggestion.line):,} candidates")
+            click.echo(f"   Why: {suggestion.why}")
+        click.echo()
+
+        if mask_out:
+            with open(mask_out, "w", encoding="utf-8") as f:
+                f.write(f"# {mask}\n")
+                for suggestion in suggestions:
+                    f.write(format_hcmask_line(suggestion.custom_charsets, suggestion.mask) + "\n")
+            click.echo(f"Done: Mask(s) written to: {mask_out}")
+        return
 
     # Handle rule explanation
     if explain:

--- a/hashcat_rosetta/cli.py
+++ b/hashcat_rosetta/cli.py
@@ -9,9 +9,13 @@ import click
 
 from .debug_analyzer import DebugAnalyzer
 from .formatting import display_rule_opcodes_summary
-from .mask import describe, format_hcmask_line, keyspace
-from .nlmask import MaskGenerationError, generate_masks
+from .mask import describe, format_hcmask_line
 from .parser import decode_hex_escapes
+
+# NOTE: hashcat_rosetta.nlmask is deliberately NOT imported here. It pulls in
+# the ``openai`` SDK, which costs ~450ms of import time that every non-LLM
+# invocation (--explain, debug-file analysis, ...) would otherwise pay. It is
+# imported lazily inside the ``--mask`` branch of main().
 
 _BANNER = r"""
  _   _           _               _   ____                _   _
@@ -855,9 +859,13 @@ def main(
 
     # Handle natural-language mask generation
     if mask:
+        # Lazy import: keeps the openai SDK out of the import path of every
+        # other command. See the note at the top of this module.
+        from . import nlmask
+
         try:
-            suggestions = generate_masks(mask, model=model, host=ollama_host)
-        except MaskGenerationError as e:
+            suggestions = nlmask.generate_masks(mask, model=model, host=ollama_host)
+        except nlmask.MaskGenerationError as e:
             click.echo(f"[!] {e}", err=True)
             sys.exit(1)
 
@@ -866,16 +874,38 @@ def main(
         for i, suggestion in enumerate(suggestions, 1):
             line_str = format_hcmask_line(suggestion.custom_charsets, suggestion.mask)
             click.echo(f"\n{i}. {line_str}")
+            # describe() already ends with "→ N candidates", so the keyspace
+            # is not printed a second time on its own line.
             click.echo(f"   {describe(suggestion.line)}")
-            click.echo(f"   Keyspace: {keyspace(suggestion.line):,} candidates")
             click.echo(f"   Why: {suggestion.why}")
         click.echo()
 
         if mask_out:
-            with open(mask_out, "w", encoding="utf-8") as f:
-                f.write(f"# {mask}\n")
-                for suggestion in suggestions:
-                    f.write(format_hcmask_line(suggestion.custom_charsets, suggestion.mask) + "\n")
+            # The description is written as a header comment; collapse any
+            # newlines so it cannot inject extra lines into the file.
+            header = " ".join(mask.splitlines())
+            lines = [
+                format_hcmask_line(suggestion.custom_charsets, suggestion.mask)
+                for suggestion in suggestions
+            ]
+            try:
+                with open(mask_out, "w", encoding="utf-8") as f:
+                    f.write(f"# {header}\n")
+                    for line_str in lines:
+                        # hashcat skips any line starting with '#' as a
+                        # comment; '\#' is its accepted escape for a literal
+                        # leading '#'.
+                        if line_str.startswith("#"):
+                            click.echo(
+                                f"[!] mask '{line_str}' starts with '#'; written as "
+                                f"'\\{line_str}' so hashcat does not treat it as a comment",
+                                err=True,
+                            )
+                            line_str = "\\" + line_str
+                        f.write(line_str + "\n")
+            except OSError as e:
+                click.echo(f"[!] could not write {mask_out}: {e}", err=True)
+                sys.exit(1)
             click.echo(f"Done: Mask(s) written to: {mask_out}")
         return
 

--- a/hashcat_rosetta/mask.py
+++ b/hashcat_rosetta/mask.py
@@ -1,0 +1,392 @@
+"""Module for parsing and validating hashcat mask syntax (hcmask).
+
+Provides deterministic parsing, validation, and keyspace computation for
+hashcat mask lines. No networking or LLM code — pure unit-testable functions.
+"""
+
+from dataclasses import dataclass
+
+
+# Builtin charsets as defined by hashcat
+BUILTIN_CHARSETS: dict[str, str] = {
+    "?l": "abcdefghijklmnopqrstuvwxyz",
+    "?u": "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    "?d": "0123456789",
+    "?h": "0123456789abcdef",
+    "?H": "0123456789ABCDEF",
+    "?s": " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~",
+    "?a": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    + " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~",
+    "?b": "".join(chr(i) for i in range(256)),
+}
+
+
+class MaskError(Exception):
+    """Raised when mask parsing or validation fails."""
+
+    pass
+
+
+@dataclass
+class HcmaskLine:
+    """Represents a parsed hcmask line.
+
+    Attributes:
+        custom: List of custom charset definitions (0-4 items).
+        mask: The mask string containing tokens and literals.
+        raw: The original unparsed line text (useful for error messages).
+    """
+
+    custom: list[str]
+    mask: str
+    raw: str
+
+
+def parse_hcmask_line(line: str) -> HcmaskLine:
+    """Parse an hcmask line into custom charsets and mask.
+
+    An hcmask line is comma-separated fields. The last field is the mask;
+    all preceding fields are custom charset definitions (max 4). Unescaped
+    commas are field separators; ``\\,`` is a literal comma within a field.
+
+    Args:
+        line: A full hcmask line string (e.g. ``abcdef,?1?1?1?d`` or
+            ``?d?d?d?d?d?d``)
+
+    Returns:
+        HcmaskLine with parsed custom charsets and mask.
+
+    Raises:
+        MaskError: If the line has >4 custom charsets, or if the mask is
+            invalid (dangling ``?``, unknown token, invalid custom charset
+            reference, etc.)
+    """
+    raw_line = line
+    # Split on unescaped commas
+    fields = _split_unescaped_commas(line)
+
+    if not fields:
+        raise MaskError("Empty hcmask line")
+
+    # Last field is the mask; all others are custom charsets
+    mask = fields[-1]
+    custom_fields = fields[:-1]
+
+    if len(custom_fields) > 4:
+        raise MaskError(f"at most 4 custom charsets allowed, got {len(custom_fields)}")
+
+    # Unescape each custom charset field
+    custom = [_unescape_field(f) for f in custom_fields]
+
+    # Validate the mask against the custom charsets
+    validate_mask(mask, custom)
+
+    return HcmaskLine(custom=custom, mask=mask, raw=raw_line)
+
+
+def _split_unescaped_commas(line: str) -> list[str]:
+    """Split a line on unescaped commas.
+
+    A comma preceded by a backslash is escaped and not a separator.
+    The backslash is not removed here; it is removed by _unescape_field().
+    """
+    fields = []
+    current = []
+    i = 0
+    while i < len(line):
+        if i > 0 and line[i] == "," and line[i - 1] == "\\":
+            # Escaped comma — include it in the current field
+            current.append(",")
+            i += 1
+        elif line[i] == ",":
+            # Unescaped comma — field separator
+            fields.append("".join(current))
+            current = []
+            i += 1
+        else:
+            current.append(line[i])
+            i += 1
+    fields.append("".join(current))
+    return fields
+
+
+def _unescape_field(field: str) -> str:
+    """Remove escape sequences from a field.
+
+    Replaces ``\\,`` with ``,``. Other backslashes are left alone
+    (hashcat behavior).
+    """
+    return field.replace("\\,", ",")
+
+
+def validate_mask(mask: str, custom: list[str]) -> None:
+    """Validate a mask string against a list of custom charsets.
+
+    Args:
+        mask: The mask string to validate.
+        custom: List of custom charset definitions (0-4 items).
+
+    Raises:
+        MaskError: If the mask is invalid (dangling ``?``, unknown token,
+            reference to non-existent custom charset, etc.)
+    """
+    i = 0
+    while i < len(mask):
+        char = mask[i]
+
+        if char == "?":
+            # Token marker — must have a following character
+            if i + 1 >= len(mask):
+                raise MaskError("dangling trailing '?'")
+
+            next_char = mask[i + 1]
+
+            # Check for escaped ?
+            if next_char == "?":
+                # ?? is a literal ?
+                i += 2
+                continue
+
+            # Check for builtin charset
+            if next_char in "ludhHsab":
+                i += 2
+                continue
+
+            # Check for custom charset reference (?1-?4)
+            if next_char in "1234":
+                custom_index = int(next_char) - 1
+                if custom_index >= len(custom):
+                    raise MaskError(
+                        f"referenced ?{next_char} but only {len(custom)} custom charset(s) provided"
+                    )
+                i += 2
+                continue
+
+            # Unknown token
+            raise MaskError(f"unknown token '?{next_char}'")
+
+        # Literal character
+        i += 1
+
+
+def tokens(line: HcmaskLine) -> list[tuple[str, int]]:
+    """Return the ordered list of tokens and their charset sizes.
+
+    Tokens are either single literal characters or mask tokens like
+    ``?d``, ``?1``, etc. Each token is paired with its charset size:
+    literals have size 1, tokens have their builtin or custom size.
+
+    Args:
+        line: A parsed HcmaskLine.
+
+    Returns:
+        List of (token_string, charset_size) pairs in order.
+    """
+    result = []
+    i = 0
+    mask = line.mask
+
+    while i < len(mask):
+        char = mask[i]
+
+        if char == "?":
+            # Token
+            if i + 1 >= len(mask):
+                # Should not happen if validate_mask was called
+                raise MaskError("dangling trailing '?'")
+
+            next_char = mask[i + 1]
+
+            # Escaped ?
+            if next_char == "?":
+                result.append(("??", 1))
+                i += 2
+                continue
+
+            # Builtin charset
+            if f"?{next_char}" in BUILTIN_CHARSETS:
+                charset = BUILTIN_CHARSETS[f"?{next_char}"]
+                result.append((f"?{next_char}", len(charset)))
+                i += 2
+                continue
+
+            # Custom charset reference
+            if next_char in "1234":
+                custom_index = int(next_char) - 1
+                if custom_index < len(line.custom):
+                    charset = line.custom[custom_index]
+                    result.append((f"?{next_char}", len(charset)))
+                i += 2
+                continue
+
+            # Should not happen if validate_mask was called
+            raise MaskError(f"unknown token '?{next_char}'")
+
+        # Literal character
+        result.append((char, 1))
+        i += 1
+
+    return result
+
+
+def keyspace(line: HcmaskLine) -> int:
+    """Compute the total keyspace (product of charset sizes).
+
+    Args:
+        line: A parsed HcmaskLine.
+
+    Returns:
+        The product of all per-position charset sizes as an arbitrary
+        precision integer.
+    """
+    tok_list = tokens(line)
+    result = 1
+    for _, size in tok_list:
+        result *= size
+    return result
+
+
+def describe(line: HcmaskLine) -> str:
+    """Generate a human-readable one-line description of the mask.
+
+    Groups consecutive identical tokens and consecutive literals, showing
+    counts and the final keyspace with thousands separators.
+
+    Args:
+        line: A parsed HcmaskLine.
+
+    Returns:
+        A string like ``literal "Summer", then 6 × digit → 1,000,000
+        candidates``.
+    """
+    tok_list = tokens(line)
+
+    if not tok_list:
+        return "empty mask → 1 candidate"
+
+    # Group consecutive identical tokens
+    groups = []
+    i = 0
+    while i < len(tok_list):
+        tok, size = tok_list[i]
+
+        # Handle literals: group consecutive single-char literals
+        if size == 1 and not tok.startswith("?"):
+            # Collect consecutive literals
+            literal_chars = [tok]
+            j = i + 1
+            while j < len(tok_list):
+                next_tok, next_size = tok_list[j]
+                if next_size == 1 and not next_tok.startswith("?"):
+                    literal_chars.append(next_tok)
+                    j += 1
+                else:
+                    break
+            groups.append(("literal", "".join(literal_chars), 1, len(literal_chars)))
+            i = j
+        else:
+            # Single token (either ?? or a charset token)
+            # Count how many consecutive identical tokens
+            count = 1
+            j = i + 1
+            while j < len(tok_list):
+                next_tok, next_size = tok_list[j]
+                if next_tok == tok and next_size == size:
+                    count += 1
+                    j += 1
+                else:
+                    break
+            groups.append(("token", tok, size, count))
+            i = j
+
+    # Format each group
+    parts = []
+    for group_type, token_or_literal, size, count in groups:
+        if group_type == "literal":
+            # Escape quotes in the literal
+            escaped = token_or_literal.replace('"', '\\"')
+            if count == 1:
+                parts.append(f'literal "{escaped}"')
+            else:
+                parts.append(f'{count} × literal "{escaped}"')
+        else:
+            # Token
+            if count == 1:
+                # Describe the token
+                description = _describe_token(token_or_literal)
+                parts.append(description)
+            else:
+                # Multiple identical tokens
+                description = _describe_token(token_or_literal)
+                parts.append(f"{count} × {description}")
+
+    # Compute keyspace
+    ks = keyspace(line)
+
+    # Format keyspace with thousands separators
+    ks_str = f"{ks:,}"
+
+    # Add scientific notation if > 10^9
+    if ks > 10**9:
+        parts.append(f"→ {ks_str} (~{ks:.1e}) candidates")
+    else:
+        parts.append(f"→ {ks_str} candidates")
+
+    return ", then ".join(parts)
+
+
+def _describe_token(token: str) -> str:
+    """Describe a single token in human-readable form.
+
+    Args:
+        token: A token like ``?d``, ``?1``, ``??``, etc.
+
+    Returns:
+        A description like ``digit``, ``custom charset 1``, ``literal ?``.
+    """
+    descriptions = {
+        "?l": "lowercase",
+        "?u": "uppercase",
+        "?d": "digit",
+        "?h": "hex (lowercase)",
+        "?H": "hex (uppercase)",
+        "?s": "special",
+        "?a": "alphanumeric+special",
+        "?b": "byte",
+        "??": "literal ?",
+    }
+
+    if token in descriptions:
+        return descriptions[token]
+
+    # Custom charset reference
+    if token in ("?1", "?2", "?3", "?4"):
+        return f"custom charset {token[1]}"
+
+    return token
+
+
+def format_hcmask_line(custom: list[str], mask: str) -> str:
+    """Format custom charsets and mask into a canonical hcmask line.
+
+    Escapes any literal commas in custom charset fields as ``\\,`` and
+    joins all fields with commas.
+
+    Args:
+        custom: List of custom charset strings (0-4 items).
+        mask: The mask string.
+
+    Returns:
+        A formatted hcmask line string.
+    """
+    fields = []
+
+    # Escape custom charsets
+    for charset in custom:
+        escaped = charset.replace(",", "\\,")
+        fields.append(escaped)
+
+    # Add mask (no escaping needed for mask field)
+    fields.append(mask)
+
+    return ",".join(fields)

--- a/hashcat_rosetta/mask.py
+++ b/hashcat_rosetta/mask.py
@@ -114,6 +114,92 @@ def _unescape_field(field: str) -> str:
     return field.replace("\\,", ",")
 
 
+def _expand_charset(field: str, prior_expanded: list[str], position: int) -> str:
+    """Expand one custom charset definition into its literal character set.
+
+    hashcat does not treat a custom charset field as an opaque literal
+    string: it scans it for the same ``?X`` tokens the mask field supports.
+    ``?l``/``?u``/``?d``/``?h``/``?H``/``?s``/``?a``/``?b`` expand to their
+    builtin character sets, ``??`` is a literal ``?``, and ``?1``-``?4`` may
+    reference an *earlier* custom charset. Everything else is a literal
+    character. hashcat then deduplicates the resulting character set, so
+    ``aa`` and ``ab?l`` are 1- and 26-character charsets respectively.
+
+    Args:
+        field: The raw (comma-unescaped) custom charset field.
+        prior_expanded: Already-expanded charsets defined before this one,
+            in order, so ``?1``-``?4`` back-references can be resolved.
+        position: 1-based index of this charset (i.e. ``1`` for ``?1``),
+            used for error messages and for rejecting self/forward
+            references.
+
+    Returns:
+        The expanded, deduplicated character set as a string.
+
+    Raises:
+        MaskError: On an empty field, a dangling trailing ``?``, an unknown
+            ``?X`` token, or a reference to a custom charset that is not
+            defined yet.
+    """
+    if not field:
+        raise MaskError(f"custom charset ?{position} is empty")
+
+    chars: list[str] = []
+    i = 0
+    while i < len(field):
+        char = field[i]
+
+        if char == "?":
+            if i + 1 >= len(field):
+                raise MaskError(f"custom charset ?{position} has a dangling trailing '?'")
+
+            next_char = field[i + 1]
+
+            if next_char == "?":
+                # ?? is a literal ?
+                chars.append("?")
+            elif f"?{next_char}" in BUILTIN_CHARSETS:
+                chars.extend(BUILTIN_CHARSETS[f"?{next_char}"])
+            elif next_char in "1234":
+                ref = int(next_char)
+                if ref >= position:
+                    raise MaskError(
+                        f"custom charset ?{position} references ?{ref}, which is not defined yet"
+                    )
+                chars.extend(prior_expanded[ref - 1])
+            else:
+                raise MaskError(f"custom charset ?{position} has unknown token '?{next_char}'")
+
+            i += 2
+            continue
+
+        # Literal character
+        chars.append(char)
+        i += 1
+
+    # hashcat deduplicates the characters of a custom charset
+    return "".join(dict.fromkeys(chars))
+
+
+def expand_custom_charsets(custom: list[str]) -> list[str]:
+    """Expand every custom charset definition, resolving back-references.
+
+    Args:
+        custom: List of raw custom charset fields (0-4 items), in order.
+
+    Returns:
+        The expanded, deduplicated charsets in the same order.
+
+    Raises:
+        MaskError: If any field is empty or malformed. See
+            :func:`_expand_charset`.
+    """
+    expanded: list[str] = []
+    for position, field in enumerate(custom, start=1):
+        expanded.append(_expand_charset(field, expanded, position))
+    return expanded
+
+
 def validate_mask(mask: str, custom: list[str]) -> None:
     """Validate a mask string against a list of custom charsets.
 
@@ -124,14 +210,15 @@ def validate_mask(mask: str, custom: list[str]) -> None:
     Raises:
         MaskError: If the mask is invalid (dangling ``?``, unknown token,
             reference to non-existent custom charset, >4 custom charsets, etc.)
+            or if any custom charset definition is empty or malformed.
     """
     if len(custom) > 4:
         raise MaskError(f"at most 4 custom charsets allowed, got {len(custom)}")
 
-    # Reject empty custom charsets (cannot generate any candidates)
-    for idx, charset in enumerate(custom, start=1):
-        if not charset:
-            raise MaskError(f"custom charset ?{idx} is empty")
+    # Custom charsets are themselves subject to ?X token grammar; expanding
+    # them here rejects empty fields, dangling '?', unknown tokens, and
+    # references to charsets that are not defined yet.
+    expand_custom_charsets(custom)
 
     i = 0
     while i < len(mask):
@@ -177,7 +264,9 @@ def tokens(line: HcmaskLine) -> list[tuple[str, int]]:
 
     Tokens are either single literal characters or mask tokens like
     ``?d``, ``?1``, etc. Each token is paired with its charset size:
-    literals have size 1, tokens have their builtin or custom size.
+    literals have size 1, tokens have their builtin or custom size. Custom
+    charset sizes are the size of the *expanded* charset (see
+    :func:`expand_custom_charsets`), not the raw field length.
 
     Args:
         line: A parsed HcmaskLine.
@@ -188,6 +277,7 @@ def tokens(line: HcmaskLine) -> list[tuple[str, int]]:
     result = []
     i = 0
     mask = line.mask
+    expanded_custom = expand_custom_charsets(line.custom)
 
     while i < len(mask):
         char = mask[i]
@@ -216,12 +306,12 @@ def tokens(line: HcmaskLine) -> list[tuple[str, int]]:
             # Custom charset reference
             if next_char in "1234":
                 custom_index = int(next_char) - 1
-                if custom_index >= len(line.custom):
+                if custom_index >= len(expanded_custom):
                     raise MaskError(
-                        f"referenced ?{next_char} but only {len(line.custom)} "
+                        f"referenced ?{next_char} but only {len(expanded_custom)} "
                         f"custom charset(s) provided"
                     )
-                charset = line.custom[custom_index]
+                charset = expanded_custom[custom_index]
                 result.append((f"?{next_char}", len(charset)))
                 i += 2
                 continue
@@ -336,11 +426,38 @@ def describe(line: HcmaskLine) -> str:
 
     # Add keyspace: scientific notation if > 10^9, otherwise just the number
     if ks > 10**9:
-        description += f" → {ks_str} (~{ks:.1e}) candidates"
+        description += f" → {ks_str} (~{_short_scientific(ks)}) candidates"
     else:
         description += f" → {ks_str} candidates"
 
     return description
+
+
+def _short_scientific(value: int) -> str:
+    """Render a non-negative int in ``d.de+NN`` scientific notation.
+
+    Equivalent to ``f"{value:.1e}"`` but done with pure integer/string math
+    so it works for keyspaces beyond the range of a Python ``float``. A mask
+    may be up to 256 positions long, so e.g. ``?b`` * 200 has a keyspace of
+    ~10^481 — converting that to a float raises ``OverflowError``.
+
+    Args:
+        value: A non-negative integer.
+
+    Returns:
+        A string like ``2.8e+14``.
+    """
+    digits = str(value)
+    exponent = len(digits) - 1
+
+    # Round to two significant digits using integer math.
+    significant = int(digits[:3].ljust(3, "0"))
+    rounded = (significant + 5) // 10
+    if rounded >= 100:
+        rounded //= 10
+        exponent += 1
+
+    return f"{rounded // 10}.{rounded % 10}e+{exponent:02d}"
 
 
 def _describe_token(token: str) -> str:

--- a/hashcat_rosetta/mask.py
+++ b/hashcat_rosetta/mask.py
@@ -24,8 +24,6 @@ BUILTIN_CHARSETS: dict[str, str] = {
 class MaskError(Exception):
     """Raised when mask parsing or validation fails."""
 
-    pass
-
 
 @dataclass
 class HcmaskLine:
@@ -65,11 +63,8 @@ def parse_hcmask_line(line: str) -> HcmaskLine:
     # Split on unescaped commas
     fields = _split_unescaped_commas(line)
 
-    if not fields:
-        raise MaskError("Empty hcmask line")
-
     # Last field is the mask; all others are custom charsets
-    mask = fields[-1]
+    mask = _unescape_field(fields[-1])
     custom_fields = fields[:-1]
 
     if len(custom_fields) > 4:
@@ -128,8 +123,16 @@ def validate_mask(mask: str, custom: list[str]) -> None:
 
     Raises:
         MaskError: If the mask is invalid (dangling ``?``, unknown token,
-            reference to non-existent custom charset, etc.)
+            reference to non-existent custom charset, >4 custom charsets, etc.)
     """
+    if len(custom) > 4:
+        raise MaskError(f"at most 4 custom charsets allowed, got {len(custom)}")
+
+    # Reject empty custom charsets (cannot generate any candidates)
+    for idx, charset in enumerate(custom, start=1):
+        if not charset:
+            raise MaskError(f"custom charset ?{idx} is empty")
+
     i = 0
     while i < len(mask):
         char = mask[i]
@@ -148,7 +151,7 @@ def validate_mask(mask: str, custom: list[str]) -> None:
                 continue
 
             # Check for builtin charset
-            if next_char in "ludhHsab":
+            if f"?{next_char}" in BUILTIN_CHARSETS:
                 i += 2
                 continue
 
@@ -213,9 +216,13 @@ def tokens(line: HcmaskLine) -> list[tuple[str, int]]:
             # Custom charset reference
             if next_char in "1234":
                 custom_index = int(next_char) - 1
-                if custom_index < len(line.custom):
-                    charset = line.custom[custom_index]
-                    result.append((f"?{next_char}", len(charset)))
+                if custom_index >= len(line.custom):
+                    raise MaskError(
+                        f"referenced ?{next_char} but only {len(line.custom)} "
+                        f"custom charset(s) provided"
+                    )
+                charset = line.custom[custom_index]
+                result.append((f"?{next_char}", len(charset)))
                 i += 2
                 continue
 
@@ -305,10 +312,8 @@ def describe(line: HcmaskLine) -> str:
         if group_type == "literal":
             # Escape quotes in the literal
             escaped = token_or_literal.replace('"', '\\"')
-            if count == 1:
-                parts.append(f'literal "{escaped}"')
-            else:
-                parts.append(f'{count} × literal "{escaped}"')
+            # Literals always show the full string, never with a count prefix
+            parts.append(f'literal "{escaped}"')
         else:
             # Token
             if count == 1:
@@ -326,13 +331,16 @@ def describe(line: HcmaskLine) -> str:
     # Format keyspace with thousands separators
     ks_str = f"{ks:,}"
 
-    # Add scientific notation if > 10^9
-    if ks > 10**9:
-        parts.append(f"→ {ks_str} (~{ks:.1e}) candidates")
-    else:
-        parts.append(f"→ {ks_str} candidates")
+    # Join parts with ", then " to build the description
+    description = ", then ".join(parts)
 
-    return ", then ".join(parts)
+    # Add keyspace: scientific notation if > 10^9, otherwise just the number
+    if ks > 10**9:
+        description += f" → {ks_str} (~{ks:.1e}) candidates"
+    else:
+        description += f" → {ks_str} candidates"
+
+    return description
 
 
 def _describe_token(token: str) -> str:
@@ -386,7 +394,8 @@ def format_hcmask_line(custom: list[str], mask: str) -> str:
         escaped = charset.replace(",", "\\,")
         fields.append(escaped)
 
-    # Add mask (no escaping needed for mask field)
-    fields.append(mask)
+    # Escape mask field (commas must be escaped as \,)
+    escaped_mask = mask.replace(",", "\\,")
+    fields.append(escaped_mask)
 
     return ",".join(fields)

--- a/hashcat_rosetta/nlmask.py
+++ b/hashcat_rosetta/nlmask.py
@@ -1,0 +1,396 @@
+"""Natural-language to hcmask generation via a local LLM.
+
+This is the only module in the package that talks to a network or imports
+``openai``. It sends an English description to a local Ollama server (using
+Ollama's OpenAI-compatible chat completions endpoint), asks for one or more
+hashcat mask suggestions in a strict JSON schema, and validates every
+suggested line through :mod:`hashcat_rosetta.mask` before returning it to the
+caller. Nothing here is imported by ``mask.py``, ``cli.py``, or
+``__init__.py`` at module scope for anything other than this validation path.
+"""
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from openai import APIConnectionError, APIStatusError, OpenAI
+
+from .mask import HcmaskLine, MaskError, format_hcmask_line, parse_hcmask_line
+
+# Default model used when neither the ``model`` argument nor the
+# ``OLLAMA_MODEL`` environment variable is set.
+_DEFAULT_MODEL = "qwen3.6:35b-a3b"
+
+# Default Ollama base URL when neither ``host`` nor ``OLLAMA_HOST`` is set.
+_DEFAULT_BASE_URL = "http://localhost:11434/v1"
+
+
+class MaskGenerationError(Exception):
+    """Raised when mask generation fails.
+
+    Covers network/connection failures talking to the model server, and the
+    case where model output still fails hcmask validation after one retry.
+    """
+
+
+@dataclass
+class MaskSuggestion:
+    """A single validated hcmask suggestion returned by the model.
+
+    Attributes:
+        mask: The mask field as suggested by the model (before custom
+            charsets are prepended), e.g. ``"?1?1?d"``.
+        custom_charsets: The custom charset strings (0-4 items) the model
+            supplied for this suggestion.
+        why: A one-clause human-readable rationale for the suggestion.
+        line: The parsed, validated :class:`~hashcat_rosetta.mask.HcmaskLine`
+            for this suggestion, so callers can compute keyspace/description
+            without re-parsing.
+    """
+
+    mask: str
+    custom_charsets: list[str]
+    why: str
+    line: HcmaskLine
+
+
+# The JSON schema for a single mask suggestion object.
+_MASK_ITEM_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "mask": {
+            "type": "string",
+            "description": (
+                "The hcmask mask field, e.g. 'Summer?d?d?d?d?d?d' or, when "
+                "referencing custom charsets, 'abc,?1?1?d'."
+            ),
+        },
+        "custom_charsets": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "0-4 custom charset strings referenced in the mask as "
+                "?1-?4, in order. Empty array if the mask uses no custom "
+                "charsets."
+            ),
+        },
+        "why": {
+            "type": "string",
+            "description": "One short clause explaining the suggestion. No step-by-step reasoning.",
+        },
+    },
+    "required": ["mask", "custom_charsets", "why"],
+    "additionalProperties": False,
+}
+
+# The inner JSON schema describing the full response shape:
+# {"masks": [{"mask": ..., "custom_charsets": [...], "why": ...}, ...]}
+#
+# This constant holds the *inner* schema dict (not the full
+# response_format wrapper with "name"/"strict" keys); generate_masks() wraps
+# it into that structure at call time.
+MASK_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "masks": {
+            "type": "array",
+            "items": _MASK_ITEM_SCHEMA,
+        }
+    },
+    "required": ["masks"],
+    "additionalProperties": False,
+}
+
+SYSTEM_PROMPT = """You are a hashcat mask (hcmask) generator. Given an English \
+description of passwords to target, produce one or more hcmask candidate patterns.
+
+## hcmask grammar reference
+
+Builtin charset tokens (each is two characters, a '?' followed by a letter):
+  ?l  lowercase a-z
+  ?u  uppercase A-Z
+  ?d  digit 0-9
+  ?h  lowercase hex 0-9a-f
+  ?H  uppercase hex 0-9A-F
+  ?s  hashcat "specials" (punctuation/symbols)
+  ?a  all printable (?l + ?u + ?d + ?s)
+  ?b  all 256 byte values
+
+'??' is a literal '?' character, not a token.
+
+You may define up to 4 custom charsets (strings of characters). Do NOT inline
+them into the mask string — return them separately in the `custom_charsets`
+array, and reference them from the mask as ?1, ?2, ?3, ?4 in the order given.
+
+Literal characters in the mask (anything that is not a '?' token) are used
+as-is, e.g. "Summer" in "Summer?d?d?d?d?d?d" is a literal prefix.
+
+## Hard constraints
+
+- NO '{n}' repetition syntax. Hashcat mask files do not support it. Expand
+  repeats explicitly: six digits is "?d?d?d?d?d?d", not "?d{6}".
+- Produce one mask object per distinct candidate pattern requested. If the
+  description describes multiple variants (e.g. "summer or winter", "either
+  4 or 6 digits"), return multiple objects in the `masks` array, one per
+  variant.
+- The `why` field must be exactly ONE short clause with no step-by-step
+  reasoning or "thinking out loud". Do not explain your reasoning process,
+  just state the rationale in a few words.
+
+Return your answer as JSON matching the provided schema."""
+
+
+def resolve_base_url(host: str | None) -> str:
+    """Resolve and normalize the Ollama base URL.
+
+    Args:
+        host: An explicit host override, or ``None`` to fall back to the
+            ``OLLAMA_HOST`` environment variable.
+
+    Returns:
+        A normalized base URL ending in ``/v1``, e.g.
+        ``http://localhost:11434/v1``. If ``host`` is ``None`` and
+        ``OLLAMA_HOST`` is unset, defaults to ``http://localhost:11434/v1``.
+
+    The normalization performed:
+        - If the value has no ``://`` scheme, ``http://`` is prepended.
+        - Any trailing ``/`` is stripped.
+        - ``/v1`` is appended unless the value already ends with it.
+    """
+    value = host if host is not None else os.environ.get("OLLAMA_HOST")
+
+    if not value:
+        return _DEFAULT_BASE_URL
+
+    if "://" not in value:
+        value = f"http://{value}"
+
+    value = value.rstrip("/")
+
+    if not value.endswith("/v1"):
+        value = f"{value}/v1"
+
+    return value
+
+
+def _strip_json_fence(text: str) -> str:
+    """Strip a leading/trailing markdown code fence from model output.
+
+    Thinking models occasionally wrap JSON in ```json ... ``` fences (or
+    stray text around it) despite being asked for raw JSON via
+    ``response_format``. This best-effort helper strips a wrapping fence so
+    ``json.loads`` has a better chance of succeeding; if there's no fence,
+    the text is returned unchanged.
+    """
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        # Drop the opening fence line (``` or ```json)
+        lines = lines[1:]
+        # Drop a trailing fence line, if present
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        stripped = "\n".join(lines)
+    return stripped
+
+
+def _parse_response_json(content: str | None) -> tuple[dict[str, Any] | None, str | None]:
+    """Parse model response content as JSON.
+
+    Returns:
+        A tuple of ``(parsed, error)``. Exactly one of the two is ``None``:
+        ``parsed`` is the decoded object on success, or ``error`` is a
+        human-readable message on failure.
+    """
+    if content is None:
+        return None, "model response had no content"
+    try:
+        return json.loads(content), None
+    except json.JSONDecodeError:
+        pass
+    try:
+        return json.loads(_strip_json_fence(content)), None
+    except json.JSONDecodeError as exc:
+        return None, f"could not parse model response as JSON: {exc}"
+
+
+def _validate_items(
+    items: list[dict[str, Any]],
+) -> tuple[list[MaskSuggestion], list[tuple[dict[str, Any], str]]]:
+    """Validate a list of raw suggestion dicts against hcmask syntax.
+
+    Args:
+        items: Raw ``{"mask": ..., "custom_charsets": [...], "why": ...}``
+            dicts as decoded from the model's JSON response.
+
+    Returns:
+        A tuple ``(suggestions, failures)`` where ``suggestions`` holds one
+        :class:`MaskSuggestion` per item that validated successfully, and
+        ``failures`` holds ``(item, error_message)`` pairs for every item
+        that failed to validate. All items are checked, not just the first
+        failure.
+    """
+    suggestions: list[MaskSuggestion] = []
+    failures: list[tuple[dict[str, Any], str]] = []
+
+    for item in items:
+        mask_field = item.get("mask", "")
+        custom_charsets = item.get("custom_charsets", [])
+        why = item.get("why", "")
+
+        raw_line = format_hcmask_line(custom_charsets, mask_field)
+        try:
+            parsed_line = parse_hcmask_line(raw_line)
+        except MaskError as exc:
+            failures.append((item, str(exc)))
+            continue
+
+        suggestions.append(
+            MaskSuggestion(
+                mask=mask_field,
+                custom_charsets=list(custom_charsets),
+                why=why,
+                line=parsed_line,
+            )
+        )
+
+    return suggestions, failures
+
+
+def _build_retry_message(failures: list[tuple[dict[str, Any], str]]) -> str:
+    """Build the user-facing retry prompt describing each failing mask."""
+    lines = [
+        "The following mask suggestion(s) failed hcmask validation. "
+        "Fix only these and resend the full corrected JSON matching the same schema:"
+    ]
+    for item, error in failures:
+        mask_field = item.get("mask", "")
+        custom_charsets = item.get("custom_charsets", [])
+        raw_line = format_hcmask_line(custom_charsets, mask_field)
+        lines.append(f'- "{raw_line}": {error}')
+    return "\n".join(lines)
+
+
+def generate_masks(
+    description: str,
+    *,
+    model: str | None = None,
+    host: str | None = None,
+    temperature: float = 0.0,
+    client: Any = None,
+) -> list[MaskSuggestion]:
+    """Generate hcmask suggestions for an English description via a local LLM.
+
+    Sends ``description`` to a local Ollama server (OpenAI-compatible chat
+    completions API), asking for JSON matching :data:`MASK_SCHEMA`. Every
+    suggested mask line is validated through
+    :func:`hashcat_rosetta.mask.parse_hcmask_line`. If any line fails
+    validation (or the response isn't valid JSON), one retry turn is sent in
+    the same conversation, listing the failures and asking for a corrected
+    response. If validation still fails after the retry, raises
+    :class:`MaskGenerationError`.
+
+    Args:
+        description: An English description of the passwords to target.
+        model: Model name to request. Falls back to the ``OLLAMA_MODEL``
+            environment variable, then to a built-in default.
+        host: Ollama base URL/host override. See :func:`resolve_base_url`.
+        temperature: Sampling temperature for the chat completion.
+        client: An optional pre-built client (e.g. a test double) exposing
+            ``.chat.completions.create(...)`` with the same signature as the
+            OpenAI SDK client. When omitted, a real ``OpenAI`` client is
+            constructed against the resolved base URL.
+
+    Returns:
+        A list of validated :class:`MaskSuggestion` objects.
+
+    Raises:
+        MaskGenerationError: If the model server can't be reached, or if
+            suggested mask lines still fail hcmask validation (or the
+            response still isn't valid JSON) after one retry.
+    """
+    base_url = resolve_base_url(host)
+    resolved_model = model if model is not None else os.environ.get("OLLAMA_MODEL", _DEFAULT_MODEL)
+
+    active_client: Any = (
+        client if client is not None else OpenAI(base_url=base_url, api_key="ollama")
+    )
+
+    response_format = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "hcmask_suggestions",
+            "strict": True,
+            "schema": MASK_SCHEMA,
+        },
+    }
+
+    messages: list[dict[str, Any]] = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": description},
+    ]
+
+    try:
+        response = active_client.chat.completions.create(
+            model=resolved_model,
+            temperature=temperature,
+            messages=messages,
+            response_format=response_format,
+        )
+    except (APIConnectionError, APIStatusError) as exc:
+        raise MaskGenerationError(f"could not reach Ollama at {base_url}: {exc}") from exc
+    except Exception as exc:  # noqa: BLE001 - network/SDK failures must not escape uncaught
+        raise MaskGenerationError(f"request to Ollama at {base_url} failed: {exc}") from exc
+
+    assistant_content = response.choices[0].message.content
+    parsed, parse_error = _parse_response_json(assistant_content)
+
+    failures: list[tuple[dict[str, Any], str]] = []
+    suggestions: list[MaskSuggestion] = []
+
+    if parsed is None:
+        failures = [({"mask": ""}, parse_error or "invalid JSON")]
+    else:
+        items = parsed.get("masks", [])
+        suggestions, failures = _validate_items(items)
+
+    if not failures:
+        return suggestions
+
+    # One retry: append the assistant's prior response, then a user message
+    # describing every failure, and ask for a corrected full response.
+    messages.append({"role": "assistant", "content": assistant_content or ""})
+    messages.append({"role": "user", "content": _build_retry_message(failures)})
+
+    try:
+        retry_response = active_client.chat.completions.create(
+            model=resolved_model,
+            temperature=temperature,
+            messages=messages,
+            response_format=response_format,
+        )
+    except (APIConnectionError, APIStatusError) as exc:
+        raise MaskGenerationError(f"could not reach Ollama at {base_url}: {exc}") from exc
+    except Exception as exc:  # noqa: BLE001 - network/SDK failures must not escape uncaught
+        raise MaskGenerationError(f"request to Ollama at {base_url} failed: {exc}") from exc
+
+    retry_content = retry_response.choices[0].message.content
+    retry_parsed, retry_parse_error = _parse_response_json(retry_content)
+
+    if retry_parsed is None:
+        raise MaskGenerationError(
+            f"model response was not valid JSON after retry: {retry_parse_error}"
+        )
+
+    retry_items = retry_parsed.get("masks", [])
+    retry_suggestions, retry_failures = _validate_items(retry_items)
+
+    if retry_failures:
+        details = "; ".join(
+            f'"{format_hcmask_line(item.get("custom_charsets", []), item.get("mask", ""))}": {error}'
+            for item, error in retry_failures
+        )
+        raise MaskGenerationError(f"mask suggestions still invalid after retry: {details}")
+
+    return retry_suggestions

--- a/hashcat_rosetta/nlmask.py
+++ b/hashcat_rosetta/nlmask.py
@@ -5,8 +5,15 @@ This is the only module in the package that talks to a network or imports
 Ollama's OpenAI-compatible chat completions endpoint), asks for one or more
 hashcat mask suggestions in a strict JSON schema, and validates every
 suggested line through :mod:`hashcat_rosetta.mask` before returning it to the
-caller. Nothing here is imported by ``mask.py``, ``cli.py``, or
-``__init__.py`` at module scope for anything other than this validation path.
+caller.
+
+Import isolation invariant: this module is the *only* place in the package
+that imports the third-party ``openai`` SDK. ``cli.py`` and ``__init__.py``
+do import names from here (``generate_masks``, ``MaskGenerationError``,
+``MaskSuggestion``) — that is expected — but they do so lazily, so that the
+cost of importing ``openai`` is paid only when the mask-generation feature is
+actually used. ``mask.py`` does not import this module at all; the dependency
+runs the other way.
 """
 
 import json
@@ -229,6 +236,57 @@ def _parse_response_json(content: str | None) -> tuple[dict[str, Any] | None, st
     return decoded, None
 
 
+def _check_item_types(index: int, mask_field: Any, custom_charsets: Any) -> str | None:
+    """Check that a suggestion item's fields have the expected types.
+
+    Args:
+        index: Position of the item in the ``masks`` array (for messages).
+        mask_field: The raw ``mask`` value from the model.
+        custom_charsets: The raw ``custom_charsets`` value from the model.
+
+    Returns:
+        ``None`` if the types are acceptable, otherwise a human-readable
+        error message suitable for the retry prompt.
+    """
+    if not isinstance(mask_field, str):
+        return f"item {index}: 'mask' must be a string (got {type(mask_field).__name__})"
+
+    if not isinstance(custom_charsets, list):
+        return (
+            f"item {index}: 'custom_charsets' must be an array of strings "
+            f"(got {type(custom_charsets).__name__})"
+        )
+
+    for position, charset in enumerate(custom_charsets):
+        if not isinstance(charset, str):
+            return (
+                f"item {index}: custom_charsets[{position}] must be a string "
+                f"(got {type(charset).__name__})"
+            )
+
+    return None
+
+
+def _placeholder_item(item: dict[str, Any]) -> dict[str, Any]:
+    """Build a type-safe stand-in for an item with wrongly-typed fields.
+
+    Failure records are later re-rendered through
+    :func:`~hashcat_rosetta.mask.format_hcmask_line`, which assumes strings,
+    so a badly-typed item is replaced by one whose ``mask`` and
+    ``custom_charsets`` are guaranteed to be a ``str`` and a ``list[str]``.
+    """
+    mask_field = item.get("mask", "")
+    custom_charsets = item.get("custom_charsets", [])
+
+    safe_mask = mask_field if isinstance(mask_field, str) else repr(mask_field)
+    if isinstance(custom_charsets, list) and all(isinstance(c, str) for c in custom_charsets):
+        safe_custom = list(custom_charsets)
+    else:
+        safe_custom = []
+
+    return {"mask": safe_mask, "custom_charsets": safe_custom, "why": ""}
+
+
 def _validate_items(
     items: list[Any],
 ) -> tuple[list[MaskSuggestion], list[tuple[dict[str, Any], str]]]:
@@ -245,8 +303,10 @@ def _validate_items(
         :class:`MaskSuggestion` per item that validated successfully, and
         ``failures`` holds ``(item, error_message)`` pairs for every item
         that failed to validate. All items are checked, not just the first
-        failure. An item that isn't a JSON object is recorded as a failure
-        (wrapped in a placeholder dict) rather than raising.
+        failure. An item that isn't a JSON object, or whose ``mask`` is not
+        a string, or whose ``custom_charsets`` is not an array of strings,
+        is recorded as a failure (wrapped in a placeholder dict) rather than
+        raising.
     """
     suggestions: list[MaskSuggestion] = []
     failures: list[tuple[dict[str, Any], str]] = []
@@ -262,6 +322,15 @@ def _validate_items(
         mask_field = item.get("mask", "")
         custom_charsets = item.get("custom_charsets", [])
         why = item.get("why", "")
+
+        # Model output is untrusted: guard field *types* before handing them
+        # to mask.py, which assumes strings. A wrong type here must be a
+        # normal validation failure (feeding the retry prompt), never an
+        # uncaught TypeError/AttributeError.
+        type_error = _check_item_types(index, mask_field, custom_charsets)
+        if type_error is not None:
+            failures.append((_placeholder_item(item), type_error))
+            continue
 
         raw_line = format_hcmask_line(custom_charsets, mask_field)
         try:

--- a/hashcat_rosetta/nlmask.py
+++ b/hashcat_rosetta/nlmask.py
@@ -200,41 +200,65 @@ def _parse_response_json(content: str | None) -> tuple[dict[str, Any] | None, st
 
     Returns:
         A tuple of ``(parsed, error)``. Exactly one of the two is ``None``:
-        ``parsed`` is the decoded object on success, or ``error`` is a
+        ``parsed`` is the decoded object on success (guaranteed to be a
+        ``dict``; a top-level JSON value that isn't an object, e.g. a bare
+        array or string, is treated as a parse failure), or ``error`` is a
         human-readable message on failure.
     """
     if content is None:
         return None, "model response had no content"
+
+    decoded: Any = None
+    decode_error: str | None = None
     try:
-        return json.loads(content), None
+        decoded = json.loads(content)
     except json.JSONDecodeError:
-        pass
-    try:
-        return json.loads(_strip_json_fence(content)), None
-    except json.JSONDecodeError as exc:
-        return None, f"could not parse model response as JSON: {exc}"
+        try:
+            decoded = json.loads(_strip_json_fence(content))
+        except json.JSONDecodeError as exc:
+            decode_error = f"could not parse model response as JSON: {exc}"
+
+    if decode_error is not None:
+        return None, decode_error
+
+    if not isinstance(decoded, dict):
+        return None, (
+            f"model response was valid JSON but not a JSON object (got {type(decoded).__name__})"
+        )
+
+    return decoded, None
 
 
 def _validate_items(
-    items: list[dict[str, Any]],
+    items: list[Any],
 ) -> tuple[list[MaskSuggestion], list[tuple[dict[str, Any], str]]]:
     """Validate a list of raw suggestion dicts against hcmask syntax.
 
     Args:
         items: Raw ``{"mask": ..., "custom_charsets": [...], "why": ...}``
-            dicts as decoded from the model's JSON response.
+            dicts as decoded from the model's JSON response. Items may be
+            malformed (e.g. not objects at all) since this is untrusted
+            model output.
 
     Returns:
         A tuple ``(suggestions, failures)`` where ``suggestions`` holds one
         :class:`MaskSuggestion` per item that validated successfully, and
         ``failures`` holds ``(item, error_message)`` pairs for every item
         that failed to validate. All items are checked, not just the first
-        failure.
+        failure. An item that isn't a JSON object is recorded as a failure
+        (wrapped in a placeholder dict) rather than raising.
     """
     suggestions: list[MaskSuggestion] = []
     failures: list[tuple[dict[str, Any], str]] = []
 
-    for item in items:
+    for index, item in enumerate(items):
+        if not isinstance(item, dict):
+            placeholder = {"mask": "", "custom_charsets": [], "why": ""}
+            failures.append(
+                (placeholder, f"item {index} is not an object (got {type(item).__name__})")
+            )
+            continue
+
         mask_field = item.get("mask", "")
         custom_charsets = item.get("custom_charsets", [])
         why = item.get("why", "")
@@ -353,7 +377,10 @@ def generate_masks(
         failures = [({"mask": ""}, parse_error or "invalid JSON")]
     else:
         items = parsed.get("masks", [])
-        suggestions, failures = _validate_items(items)
+        if not items:
+            failures = [({"mask": ""}, "response contained an empty 'masks' array")]
+        else:
+            suggestions, failures = _validate_items(items)
 
     if not failures:
         return suggestions
@@ -384,6 +411,12 @@ def generate_masks(
         )
 
     retry_items = retry_parsed.get("masks", [])
+
+    if not retry_items:
+        raise MaskGenerationError(
+            f"model returned no mask suggestions for this description: {description!r}"
+        )
+
     retry_suggestions, retry_failures = _validate_items(retry_items)
 
     if retry_failures:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ authors = [
 
 dependencies = [
     "click>=8.0.0",
+    "openai>=2.52.0",
 ]
 
 [dependency-groups]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,8 @@ import pytest
 from click.testing import CliRunner
 
 from hashcat_rosetta.cli import _escape_bytes, explain_rule, main
+from hashcat_rosetta.mask import parse_hcmask_line
+from hashcat_rosetta.nlmask import MaskGenerationError, MaskSuggestion
 
 
 # Shared fixtures
@@ -530,3 +532,51 @@ class TestExplainCliByteRendering:
         # The raw U+0099 code point (which would UTF-8-encode to c2 99) must not
         # appear in the user-facing output.
         assert "\x99" not in result.output
+
+
+# --- --mask natural-language generation ---
+
+
+class TestMaskGeneration:
+    """Covers the --mask branch wired to nlmask.generate_masks."""
+
+    def _suggestion(self, mask="Summer?d?d?d?d?d?d", why="a season plus a six digit year/PIN"):
+        line = parse_hcmask_line(mask)
+        return MaskSuggestion(mask=mask, custom_charsets=[], why=why, line=line)
+
+    def test_mask_prints_line_and_keyspace(self, runner, monkeypatch):
+        suggestion = self._suggestion()
+        monkeypatch.setattr("hashcat_rosetta.cli.generate_masks", lambda *a, **k: [suggestion])
+        result = runner.invoke(main, ["--mask", "Summer followed by six digits"])
+        assert result.exit_code == 0
+        assert "Summer?d?d?d?d?d?d" in result.output
+        assert "1,000,000" in result.output
+
+    def test_mask_does_not_require_file(self, runner, monkeypatch):
+        suggestion = self._suggestion()
+        monkeypatch.setattr("hashcat_rosetta.cli.generate_masks", lambda *a, **k: [suggestion])
+        result = runner.invoke(main, ["--mask", "Summer followed by six digits"])
+        assert result.exit_code == 0
+        assert "FILE is required" not in result.output
+
+    def test_mask_out_writes_file(self, runner, monkeypatch, tmp_path):
+        suggestion = self._suggestion()
+        monkeypatch.setattr("hashcat_rosetta.cli.generate_masks", lambda *a, **k: [suggestion])
+        out_path = tmp_path / "out.hcmask"
+        result = runner.invoke(
+            main, ["--mask", "Summer followed by six digits", "-o", str(out_path)]
+        )
+        assert result.exit_code == 0
+        assert str(out_path) in result.output
+        contents = out_path.read_text()
+        assert "Summer?d?d?d?d?d?d" in contents
+        assert contents.startswith("#")
+
+    def test_mask_generation_error_exits_nonzero(self, runner, monkeypatch):
+        def _raise(*args, **kwargs):
+            raise MaskGenerationError("could not reach Ollama at http://localhost:11434/v1")
+
+        monkeypatch.setattr("hashcat_rosetta.cli.generate_masks", _raise)
+        result = runner.invoke(main, ["--mask", "Summer followed by six digits"])
+        assert result.exit_code == 1
+        assert "could not reach Ollama" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -546,7 +546,7 @@ class TestMaskGeneration:
 
     def test_mask_prints_line_and_keyspace(self, runner, monkeypatch):
         suggestion = self._suggestion()
-        monkeypatch.setattr("hashcat_rosetta.cli.generate_masks", lambda *a, **k: [suggestion])
+        monkeypatch.setattr("hashcat_rosetta.nlmask.generate_masks", lambda *a, **k: [suggestion])
         result = runner.invoke(main, ["--mask", "Summer followed by six digits"])
         assert result.exit_code == 0
         assert "Summer?d?d?d?d?d?d" in result.output
@@ -554,14 +554,14 @@ class TestMaskGeneration:
 
     def test_mask_does_not_require_file(self, runner, monkeypatch):
         suggestion = self._suggestion()
-        monkeypatch.setattr("hashcat_rosetta.cli.generate_masks", lambda *a, **k: [suggestion])
+        monkeypatch.setattr("hashcat_rosetta.nlmask.generate_masks", lambda *a, **k: [suggestion])
         result = runner.invoke(main, ["--mask", "Summer followed by six digits"])
         assert result.exit_code == 0
         assert "FILE is required" not in result.output
 
     def test_mask_out_writes_file(self, runner, monkeypatch, tmp_path):
         suggestion = self._suggestion()
-        monkeypatch.setattr("hashcat_rosetta.cli.generate_masks", lambda *a, **k: [suggestion])
+        monkeypatch.setattr("hashcat_rosetta.nlmask.generate_masks", lambda *a, **k: [suggestion])
         out_path = tmp_path / "out.hcmask"
         result = runner.invoke(
             main, ["--mask", "Summer followed by six digits", "-o", str(out_path)]
@@ -576,7 +576,81 @@ class TestMaskGeneration:
         def _raise(*args, **kwargs):
             raise MaskGenerationError("could not reach Ollama at http://localhost:11434/v1")
 
-        monkeypatch.setattr("hashcat_rosetta.cli.generate_masks", _raise)
+        monkeypatch.setattr("hashcat_rosetta.nlmask.generate_masks", _raise)
         result = runner.invoke(main, ["--mask", "Summer followed by six digits"])
         assert result.exit_code == 1
         assert "could not reach Ollama" in result.output
+
+    def test_keyspace_is_not_printed_twice(self, runner, monkeypatch):
+        # describe() already ends with "→ N candidates"; there must not be a
+        # second, redundant "Keyspace: N candidates" line.
+        suggestion = self._suggestion()
+        monkeypatch.setattr("hashcat_rosetta.nlmask.generate_masks", lambda *a, **k: [suggestion])
+        result = runner.invoke(main, ["--mask", "Summer followed by six digits"])
+        assert result.exit_code == 0
+        assert result.output.count("1,000,000") == 1
+        assert "Keyspace:" not in result.output
+
+    def test_model_and_host_flags_reach_generate_masks(self, runner, monkeypatch):
+        # A lambda accepting *a/**k would not catch a kwarg-wiring bug, so
+        # record the actual call and assert on it.
+        calls = []
+
+        def _record(description, **kwargs):
+            calls.append((description, kwargs))
+            return [self._suggestion()]
+
+        monkeypatch.setattr("hashcat_rosetta.nlmask.generate_masks", _record)
+        result = runner.invoke(
+            main,
+            [
+                "--mask",
+                "Summer followed by six digits",
+                "--model",
+                "somemodel",
+                "--ollama-host",
+                "http://somehost:1234",
+            ],
+        )
+        assert result.exit_code == 0
+        assert len(calls) == 1
+        description, kwargs = calls[0]
+        assert description == "Summer followed by six digits"
+        assert kwargs["model"] == "somemodel"
+        assert kwargs["host"] == "http://somehost:1234"
+
+    def test_mask_out_unwritable_path_exits_cleanly(self, runner, monkeypatch, tmp_path):
+        suggestion = self._suggestion()
+        monkeypatch.setattr("hashcat_rosetta.nlmask.generate_masks", lambda *a, **k: [suggestion])
+        # A path whose parent directory does not exist.
+        out_path = tmp_path / "no-such-dir" / "out.hcmask"
+        result = runner.invoke(
+            main, ["--mask", "Summer followed by six digits", "-o", str(out_path)]
+        )
+        assert result.exit_code == 1
+        assert "[!] could not write" in result.output
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+
+    def test_mask_out_header_collapses_newlines(self, runner, monkeypatch, tmp_path):
+        suggestion = self._suggestion()
+        monkeypatch.setattr("hashcat_rosetta.nlmask.generate_masks", lambda *a, **k: [suggestion])
+        out_path = tmp_path / "out.hcmask"
+        result = runner.invoke(main, ["--mask", "line one\nline two", "-o", str(out_path)])
+        assert result.exit_code == 0
+        lines = out_path.read_text().splitlines()
+        # Exactly one comment line, then one mask line.
+        assert lines[0] == "# line one line two"
+        assert lines[1] == "Summer?d?d?d?d?d?d"
+        assert len(lines) == 2
+
+    def test_mask_out_escapes_leading_hash(self, runner, monkeypatch, tmp_path):
+        # hashcat treats a line starting with '#' as a comment and would
+        # silently skip the mask; '\#' is its escape for a literal '#'.
+        suggestion = self._suggestion(mask="#?d?d?d?d")
+        monkeypatch.setattr("hashcat_rosetta.nlmask.generate_masks", lambda *a, **k: [suggestion])
+        out_path = tmp_path / "out.hcmask"
+        result = runner.invoke(main, ["--mask", "a hash then four digits", "-o", str(out_path)])
+        assert result.exit_code == 0
+        lines = out_path.read_text().splitlines()
+        assert lines[1] == "\\#?d?d?d?d"
+        assert "starts with '#'" in result.output

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -111,12 +111,22 @@ class TestEscapedCommas:
         assert line.mask == "?1?2"
 
     def test_escaped_comma_in_mask_not_separates(self):
-        # Escaped comma in mask field (last field) — no unescaping happens
-        # Actually, since mask is the last field, escaped commas there stay
-        # as-is and are not treated as field separators. But they don't get
-        # unescaped either because mask is not unescaped.
-        # Round-trip tests below will cover comma handling comprehensively.
-        pass  # Skip for now; we'll test via round-trip
+        # Escaped comma in mask field — should be treated as literal comma,
+        # not as a field separator. The comma should be unescaped during parse.
+        line = parse_hcmask_line("?d?d\\,test")
+        # Mask field contains a literal comma (after unescaping)
+        assert line.mask == "?d?d,test"
+        assert line.custom == []
+
+    def test_escaped_comma_in_mask_roundtrip(self):
+        # Comma in mask must be escaped on output for round-trip property
+        original = "?d?d\\,test"
+        line = parse_hcmask_line(original)
+        # Mask should have unescaped comma
+        assert line.mask == "?d?d,test"
+        # Re-format should re-escape it
+        formatted = format_hcmask_line(line.custom, line.mask)
+        assert formatted == original
 
 
 class TestEscapedQuestion:
@@ -305,8 +315,10 @@ class TestDescribe:
         # ?b is 256, so ?b^6 = 256^6 = 281,474,976,710,656 > 10^9
         line = parse_hcmask_line("?b?b?b?b?b?b")
         desc = describe(line)
-        # Should contain both the full number and scientific notation
-        assert "e+" in desc or "e" in desc  # Scientific notation
+        # Should contain the full number with thousands separators
+        assert "281,474,976,710,656" in desc
+        # Should contain scientific notation in the exact format
+        assert "(~2.8e+14)" in desc
 
     def test_describe_custom_charset(self):
         line = parse_hcmask_line("abc,?1?1?1")
@@ -377,11 +389,10 @@ class TestEdgeCases:
     """Test edge cases and corner cases."""
 
     def test_empty_custom_charset(self):
-        # Custom charset can be empty (size 0), which would make keyspace 0
-        # But this might not be meaningful. For now, allow it.
-        line = HcmaskLine(custom=[""], mask="?1", raw="")
-        # tokenizing will work but keyspace is 0
-        assert keyspace(line) == 0
+        # Empty custom charsets are invalid — they cannot generate any candidates.
+        # validate_mask should reject them with a clear error.
+        with pytest.raises(MaskError, match="custom charset \\?1 is empty"):
+            validate_mask("?1", [""])
 
     def test_all_escapes_in_custom_charset(self):
         # Custom charset with only escaped commas

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -1,0 +1,460 @@
+"""Tests for hashcat mask parsing, validation, and keyspace computation."""
+
+import pytest
+
+from hashcat_rosetta.mask import (
+    BUILTIN_CHARSETS,
+    HcmaskLine,
+    MaskError,
+    describe,
+    format_hcmask_line,
+    keyspace,
+    parse_hcmask_line,
+    tokens,
+    validate_mask,
+)
+
+
+class TestBuiltinCharsets:
+    """Test that builtin charsets have correct sizes."""
+
+    def test_lowercase_size(self):
+        assert len(BUILTIN_CHARSETS["?l"]) == 26
+
+    def test_uppercase_size(self):
+        assert len(BUILTIN_CHARSETS["?u"]) == 26
+
+    def test_digit_size(self):
+        assert len(BUILTIN_CHARSETS["?d"]) == 10
+
+    def test_hex_lowercase_size(self):
+        assert len(BUILTIN_CHARSETS["?h"]) == 16
+
+    def test_hex_uppercase_size(self):
+        assert len(BUILTIN_CHARSETS["?H"]) == 16
+
+    def test_special_size(self):
+        assert len(BUILTIN_CHARSETS["?s"]) == 33
+
+    def test_alphanumeric_special_size(self):
+        assert len(BUILTIN_CHARSETS["?a"]) == 95
+
+    def test_byte_size(self):
+        assert len(BUILTIN_CHARSETS["?b"]) == 256
+
+    def test_special_charset_content(self):
+        # Verify the special charset matches the expected set
+        expected = " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+        assert BUILTIN_CHARSETS["?s"] == expected
+
+
+class TestParseSimpleMasks:
+    """Test parsing masks without custom charsets."""
+
+    def test_parse_digits_only(self):
+        line = parse_hcmask_line("?d?d?d?d")
+        assert line.custom == []
+        assert line.mask == "?d?d?d?d"
+        assert line.raw == "?d?d?d?d"
+
+    def test_parse_literal_only(self):
+        line = parse_hcmask_line("Summer")
+        assert line.custom == []
+        assert line.mask == "Summer"
+
+    def test_parse_mixed_literal_and_token(self):
+        line = parse_hcmask_line("Summer?d?d?d?d?d?d")
+        assert line.custom == []
+        assert line.mask == "Summer?d?d?d?d?d?d"
+
+
+class TestParseCustomCharsets:
+    """Test parsing with custom charsets."""
+
+    def test_one_custom_charset(self):
+        line = parse_hcmask_line("abcdef,?1?1?1?1")
+        assert line.custom == ["abcdef"]
+        assert line.mask == "?1?1?1?1"
+
+    def test_two_custom_charsets(self):
+        line = parse_hcmask_line("abc,def,?1?2?1?2")
+        assert line.custom == ["abc", "def"]
+        assert line.mask == "?1?2?1?2"
+
+    def test_three_custom_charsets(self):
+        line = parse_hcmask_line("a,b,c,?1?2?3?1")
+        assert line.custom == ["a", "b", "c"]
+        assert line.mask == "?1?2?3?1"
+
+    def test_four_custom_charsets(self):
+        line = parse_hcmask_line("a,b,c,d,?1?2?3?4")
+        assert line.custom == ["a", "b", "c", "d"]
+        assert line.mask == "?1?2?3?4"
+
+
+class TestEscapedCommas:
+    """Test handling of escaped commas in custom charsets."""
+
+    def test_escaped_comma_in_custom_charset(self):
+        line = parse_hcmask_line("a\\,b,?1?1?1")
+        assert line.custom == ["a,b"]
+        assert line.mask == "?1?1?1"
+
+    def test_multiple_escaped_commas(self):
+        line = parse_hcmask_line("a\\,b\\,c,?1?1")
+        assert line.custom == ["a,b,c"]
+        assert line.mask == "?1?1"
+
+    def test_escaped_comma_followed_by_unescaped(self):
+        line = parse_hcmask_line("a\\,b,c,?1?2")
+        assert line.custom == ["a,b", "c"]
+        assert line.mask == "?1?2"
+
+    def test_escaped_comma_in_mask_not_separates(self):
+        # Escaped comma in mask field (last field) — no unescaping happens
+        # Actually, since mask is the last field, escaped commas there stay
+        # as-is and are not treated as field separators. But they don't get
+        # unescaped either because mask is not unescaped.
+        # Round-trip tests below will cover comma handling comprehensively.
+        pass  # Skip for now; we'll test via round-trip
+
+
+class TestEscapedQuestion:
+    """Test handling of escaped question marks (literal ?)."""
+
+    def test_escaped_question_mark(self):
+        line = parse_hcmask_line("Password??2024")
+        assert line.mask == "Password??2024"
+        assert line.custom == []
+
+    def test_multiple_escaped_questions(self):
+        line = parse_hcmask_line("??hello??")
+        assert line.mask == "??hello??"
+
+
+class TestValidationErrors:
+    """Test validation of invalid masks."""
+
+    def test_dangling_trailing_question(self):
+        with pytest.raises(MaskError, match="dangling trailing"):
+            parse_hcmask_line("?d?d?")
+
+    def test_unknown_token(self):
+        with pytest.raises(MaskError, match="unknown token"):
+            parse_hcmask_line("?z?d?d")
+
+    def test_reference_to_nonexistent_custom_charset(self):
+        with pytest.raises(MaskError, match="referenced \\?1"):
+            parse_hcmask_line("?1?1?1")  # No custom charset provided
+
+    def test_reference_to_custom_charset_higher_than_provided(self):
+        with pytest.raises(MaskError, match="referenced \\?3"):
+            # Only ?1 and ?2 are provided
+            parse_hcmask_line("a,b,?1?2?3")
+
+    def test_too_many_custom_charsets(self):
+        with pytest.raises(MaskError, match="at most 4 custom charsets"):
+            parse_hcmask_line("a,b,c,d,e,?1")
+
+    def test_validate_mask_directly_unknown_token(self):
+        with pytest.raises(MaskError, match="unknown token"):
+            validate_mask("?z", [])
+
+    def test_validate_mask_directly_dangling_question(self):
+        with pytest.raises(MaskError, match="dangling trailing"):
+            validate_mask("test?", [])
+
+    def test_validate_mask_directly_bad_reference(self):
+        with pytest.raises(MaskError, match="referenced \\?2"):
+            validate_mask("?1?2", ["abc"])
+
+
+class TestTokens:
+    """Test the tokens() function."""
+
+    def test_tokens_literal_only(self):
+        line = parse_hcmask_line("abc")
+        tok_list = tokens(line)
+        assert tok_list == [("a", 1), ("b", 1), ("c", 1)]
+
+    def test_tokens_single_digit(self):
+        line = parse_hcmask_line("?d")
+        tok_list = tokens(line)
+        assert tok_list == [("?d", 10)]
+
+    def test_tokens_mixed(self):
+        line = parse_hcmask_line("Summer?d?d?d?d?d?d")
+        tok_list = tokens(line)
+        expected = [
+            ("S", 1),
+            ("u", 1),
+            ("m", 1),
+            ("m", 1),
+            ("e", 1),
+            ("r", 1),
+            ("?d", 10),
+            ("?d", 10),
+            ("?d", 10),
+            ("?d", 10),
+            ("?d", 10),
+            ("?d", 10),
+        ]
+        assert tok_list == expected
+
+    def test_tokens_escaped_question(self):
+        line = parse_hcmask_line("Pass??2024")
+        tok_list = tokens(line)
+        # ?? is a single token with size 1
+        expected = [
+            ("P", 1),
+            ("a", 1),
+            ("s", 1),
+            ("s", 1),
+            ("??", 1),
+            ("2", 1),
+            ("0", 1),
+            ("2", 1),
+            ("4", 1),
+        ]
+        assert tok_list == expected
+
+    def test_tokens_custom_charset(self):
+        line = parse_hcmask_line("abc,?1?1?d")
+        tok_list = tokens(line)
+        # ?1 has size 3 (length of "abc"), ?d has size 10
+        assert tok_list == [("?1", 3), ("?1", 3), ("?d", 10)]
+
+    def test_tokens_empty_mask(self):
+        # Edge case: empty mask — technically valid but unusual
+        line = HcmaskLine(custom=[], mask="", raw="")
+        tok_list = tokens(line)
+        assert tok_list == []
+
+
+class TestKeyspace:
+    """Test keyspace calculation."""
+
+    def test_keyspace_single_digit(self):
+        line = parse_hcmask_line("?d")
+        assert keyspace(line) == 10
+
+    def test_keyspace_summer_six_digits(self):
+        # Summer?d?d?d?d?d?d
+        # Summer is 6 literals (size 1 each), then 6 digits (size 10 each)
+        # Total: 1 * 10^6 = 1,000,000
+        line = parse_hcmask_line("Summer?d?d?d?d?d?d")
+        assert keyspace(line) == 1_000_000
+
+    def test_keyspace_byte_only(self):
+        # ?b is 256 bytes
+        line = parse_hcmask_line("?b")
+        assert keyspace(line) == 256
+
+    def test_keyspace_custom_charset(self):
+        # abc (size 3) followed by ?d (size 10) three times
+        # 3 * 10 * 10 * 10 = 3000
+        line = parse_hcmask_line("abc,?1?d?d?d")
+        assert keyspace(line) == 3 * 10 * 10 * 10
+
+    def test_keyspace_all_builtin_charsets(self):
+        # Check each builtin charset produces correct keyspace
+        cases = [
+            ("?l", 26),
+            ("?u", 26),
+            ("?d", 10),
+            ("?h", 16),
+            ("?H", 16),
+            ("?s", 33),
+            ("?a", 95),
+            ("?b", 256),
+        ]
+        for mask_str, expected_size in cases:
+            line = parse_hcmask_line(mask_str)
+            assert keyspace(line) == expected_size, f"Failed for {mask_str}"
+
+
+class TestDescribe:
+    """Test the describe() function."""
+
+    def test_describe_digits(self):
+        line = parse_hcmask_line("?d?d?d?d")
+        desc = describe(line)
+        assert "digit" in desc
+        assert "4 ×" in desc
+        assert "10,000" in desc
+
+    def test_describe_summer_six_digits(self):
+        line = parse_hcmask_line("Summer?d?d?d?d?d?d")
+        desc = describe(line)
+        assert "Summer" in desc
+        assert "digit" in desc
+        assert "1,000,000" in desc
+
+    def test_describe_empty_mask(self):
+        line = HcmaskLine(custom=[], mask="", raw="")
+        desc = describe(line)
+        assert "empty mask" in desc or desc == "empty mask → 1 candidate"
+
+    def test_describe_includes_thousands_separator(self):
+        line = parse_hcmask_line("?d?d?d?d?d?d?d?d")  # 10^8 = 100,000,000
+        desc = describe(line)
+        assert "100,000,000" in desc
+
+    def test_describe_scientific_notation_for_large_keyspace(self):
+        # Use ?b (256) repeated to get >10^9
+        # ?b is 256, so ?b^6 = 256^6 = 281,474,976,710,656 > 10^9
+        line = parse_hcmask_line("?b?b?b?b?b?b")
+        desc = describe(line)
+        # Should contain both the full number and scientific notation
+        assert "e+" in desc or "e" in desc  # Scientific notation
+
+    def test_describe_custom_charset(self):
+        line = parse_hcmask_line("abc,?1?1?1")
+        desc = describe(line)
+        # Should mention custom charset 1
+        assert "custom charset 1" in desc
+        # Keyspace is 3^3 = 27
+        assert "27" in desc
+
+
+class TestFormatHcmaskLine:
+    """Test the format_hcmask_line() function."""
+
+    def test_format_no_custom_charsets(self):
+        result = format_hcmask_line([], "?d?d?d?d")
+        assert result == "?d?d?d?d"
+
+    def test_format_one_custom_charset(self):
+        result = format_hcmask_line(["abcdef"], "?1?1?1?1")
+        assert result == "abcdef,?1?1?1?1"
+
+    def test_format_multiple_custom_charsets(self):
+        result = format_hcmask_line(["abc", "def"], "?1?2?1?2")
+        assert result == "abc,def,?1?2?1?2"
+
+    def test_format_custom_charset_with_comma(self):
+        # Custom charset containing a literal comma
+        result = format_hcmask_line(["a,b"], "?1?1")
+        assert result == "a\\,b,?1?1"
+
+    def test_format_multiple_custom_with_commas(self):
+        result = format_hcmask_line(["a,b", "c,d"], "?1?2")
+        assert result == "a\\,b,c\\,d,?1?2"
+
+
+class TestRoundTrip:
+    """Test that parse_hcmask_line and format_hcmask_line round-trip correctly."""
+
+    def test_roundtrip_no_custom(self):
+        original = "?d?d?d?d"
+        line = parse_hcmask_line(original)
+        formatted = format_hcmask_line(line.custom, line.mask)
+        assert formatted == original
+
+    def test_roundtrip_one_custom(self):
+        original = "abcdef,?1?1?1"
+        line = parse_hcmask_line(original)
+        formatted = format_hcmask_line(line.custom, line.mask)
+        assert formatted == original
+
+    def test_roundtrip_with_escaped_comma(self):
+        original = "a\\,b,?1?1"
+        line = parse_hcmask_line(original)
+        # After parsing, the custom charset should be unescaped
+        assert line.custom == ["a,b"]
+        # When formatting, it should be re-escaped
+        formatted = format_hcmask_line(line.custom, line.mask)
+        assert formatted == original
+
+    def test_roundtrip_multiple_with_commas(self):
+        original = "a\\,b,c\\,d,?1?2"
+        line = parse_hcmask_line(original)
+        formatted = format_hcmask_line(line.custom, line.mask)
+        assert formatted == original
+
+
+class TestEdgeCases:
+    """Test edge cases and corner cases."""
+
+    def test_empty_custom_charset(self):
+        # Custom charset can be empty (size 0), which would make keyspace 0
+        # But this might not be meaningful. For now, allow it.
+        line = HcmaskLine(custom=[""], mask="?1", raw="")
+        # tokenizing will work but keyspace is 0
+        assert keyspace(line) == 0
+
+    def test_all_escapes_in_custom_charset(self):
+        # Custom charset with only escaped commas
+        line = parse_hcmask_line("a\\,\\,b,?1")
+        assert line.custom == ["a,,b"]
+        assert keyspace(line) == 4  # length of "a,,b"
+
+    def test_question_mark_in_middle_of_custom(self):
+        # Question marks in custom charsets are literal (no unescaping in
+        # custom fields)
+        line = parse_hcmask_line("a?b,?1?1")
+        assert line.custom == ["a?b"]
+        assert keyspace(line) == 3 * 3  # custom charset "a?b" has length 3
+
+    def test_mask_with_special_literals(self):
+        # Mask can contain any literal characters (including special ones)
+        line = parse_hcmask_line("!@#$%?d?d")
+        tok_list = tokens(line)
+        assert tok_list[0] == ("!", 1)
+        assert tok_list[1] == ("@", 1)
+        assert tok_list[2] == ("#", 1)
+        assert tok_list[3] == ("$", 1)
+        assert tok_list[4] == ("%", 1)
+        assert tok_list[5] == ("?d", 10)
+        assert tok_list[6] == ("?d", 10)
+
+    def test_large_custom_charset(self):
+        # Custom charset with many characters
+        large_charset = "abcdefghijklmnopqrstuvwxyz"
+        line = parse_hcmask_line(f"{large_charset},?1?1")
+        assert len(line.custom[0]) == 26
+        assert keyspace(line) == 26 * 26
+
+
+class TestMaskErrorMessages:
+    """Test that error messages are precise and helpful."""
+
+    def test_error_message_dangling_question(self):
+        with pytest.raises(MaskError) as exc_info:
+            parse_hcmask_line("?d?")
+        assert "dangling" in str(exc_info.value).lower()
+
+    def test_error_message_unknown_token(self):
+        with pytest.raises(MaskError) as exc_info:
+            parse_hcmask_line("?z")
+        assert "unknown" in str(exc_info.value).lower()
+        assert "?z" in str(exc_info.value)
+
+    def test_error_message_missing_charset(self):
+        with pytest.raises(MaskError) as exc_info:
+            parse_hcmask_line("?2?2")
+        assert "?2" in str(exc_info.value)
+        assert "referenced" in str(exc_info.value).lower()
+
+    def test_error_message_too_many_charsets(self):
+        with pytest.raises(MaskError) as exc_info:
+            parse_hcmask_line("a,b,c,d,e,?1")
+        assert "4" in str(exc_info.value)
+        assert "5" in str(exc_info.value)
+
+
+class TestHcmaskLineDataclass:
+    """Test the HcmaskLine dataclass."""
+
+    def test_hcmask_line_creation(self):
+        line = HcmaskLine(custom=["abc"], mask="?1?d", raw="abc,?1?d")
+        assert line.custom == ["abc"]
+        assert line.mask == "?1?d"
+        assert line.raw == "abc,?1?d"
+
+    def test_hcmask_line_from_parse(self):
+        parsed = parse_hcmask_line("abc,?1?1")
+        assert isinstance(parsed, HcmaskLine)
+        assert parsed.custom == ["abc"]
+        assert parsed.mask == "?1?1"
+        assert parsed.raw == "abc,?1?1"

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -7,12 +7,14 @@ from hashcat_rosetta.mask import (
     HcmaskLine,
     MaskError,
     describe,
+    expand_custom_charsets,
     format_hcmask_line,
     keyspace,
     parse_hcmask_line,
     tokens,
     validate_mask,
 )
+from hashcat_rosetta.mask import _short_scientific
 
 
 class TestBuiltinCharsets:
@@ -395,17 +397,20 @@ class TestEdgeCases:
             validate_mask("?1", [""])
 
     def test_all_escapes_in_custom_charset(self):
-        # Custom charset with only escaped commas
+        # Custom charset with only escaped commas. hashcat deduplicates the
+        # characters of a custom charset, so "a,,b" is the 3-char set {a , b}.
+        # Verified: `hashcat --stdout -a 3` on "a\,\,b,?1" emits b, a, ",".
         line = parse_hcmask_line("a\\,\\,b,?1")
         assert line.custom == ["a,,b"]
-        assert keyspace(line) == 4  # length of "a,,b"
+        assert keyspace(line) == 3
 
     def test_question_mark_in_middle_of_custom(self):
-        # Question marks in custom charsets are literal (no unescaping in
-        # custom fields)
+        # hashcat expands ?X tokens INSIDE a custom charset definition too, so
+        # "a?b" is 'a' plus all 256 byte values, deduplicated => 256 chars.
+        # Verified: `hashcat --stdout -a 3` on "a?b,?1?1" emits 65536 candidates.
         line = parse_hcmask_line("a?b,?1?1")
         assert line.custom == ["a?b"]
-        assert keyspace(line) == 3 * 3  # custom charset "a?b" has length 3
+        assert keyspace(line) == 256 * 256
 
     def test_mask_with_special_literals(self):
         # Mask can contain any literal characters (including special ones)
@@ -469,3 +474,94 @@ class TestHcmaskLineDataclass:
         assert parsed.custom == ["abc"]
         assert parsed.mask == "?1?1"
         assert parsed.raw == "abc,?1?1"
+
+
+class TestCustomCharsetExpansion:
+    """hashcat expands ?X tokens inside custom charset *definitions* too.
+
+    Every expected value in this class was cross-checked against the real
+    hashcat binary (v7.1.2) with `hashcat --stdout -a 3 <file.hcmask>`.
+    """
+
+    def test_builtin_tokens_expand_inside_custom_charset(self):
+        # "?l?d" is 26 + 10 = 36 characters, not the 4-character literal
+        # string. hashcat --stdout emits 36^4 = 1,679,616 candidates.
+        line = parse_hcmask_line("?l?d,?1?1?1?1")
+        assert keyspace(line) == 1_679_616
+        assert keyspace(line) == 36**4
+
+    def test_expand_charset_returns_deduplicated_set(self):
+        # hashcat deduplicates: "ab?l" is just the 26 lowercase letters.
+        assert expand_custom_charsets(["ab?l"]) == [BUILTIN_CHARSETS["?l"]]
+        assert expand_custom_charsets(["aa"]) == ["a"]
+        assert expand_custom_charsets(["?l?d"]) == [BUILTIN_CHARSETS["?l"] + BUILTIN_CHARSETS["?d"]]
+
+    def test_byte_token_inside_custom_charset(self):
+        # "a?b" => 'a' plus 256 byte values, deduplicated => 256.
+        line = parse_hcmask_line("a?b,?1?1")
+        assert keyspace(line) == 65_536
+
+    def test_double_question_is_literal_inside_custom_charset(self):
+        # "a??b" is the 3-char set {a, ?, b}: hashcat emits 3 candidates.
+        line = parse_hcmask_line("a??b,?1")
+        assert keyspace(line) == 3
+        assert expand_custom_charsets(["a??b"]) == ["a?b"]
+
+    def test_tokens_reports_expanded_custom_size(self):
+        line = parse_hcmask_line("?d?d,?1?1")
+        # "?d?d" deduplicates back down to the 10 digits.
+        assert tokens(line) == [("?1", 10), ("?1", 10)]
+
+    def test_custom_charset_may_reference_an_earlier_one(self):
+        # Verified: "abc,?1?d,?2?2" emits 169 candidates (13^2).
+        line = parse_hcmask_line("abc,?1?d,?2?2")
+        assert keyspace(line) == 169
+
+    def test_custom_charset_cannot_reference_itself_or_a_later_one(self):
+        with pytest.raises(MaskError, match="not defined yet"):
+            parse_hcmask_line("ab?1,?1")
+        with pytest.raises(MaskError, match="not defined yet"):
+            parse_hcmask_line("abc,?2,?1")
+
+    def test_dangling_question_in_custom_charset_raises(self):
+        # hashcat: "Syntax error in mask: abc?"
+        with pytest.raises(MaskError, match="dangling trailing"):
+            parse_hcmask_line("abc?,?1")
+
+    def test_unknown_token_in_custom_charset_raises(self):
+        # hashcat: "Syntax error in mask: ab?z"
+        with pytest.raises(MaskError, match=r"unknown token '\?z'"):
+            parse_hcmask_line("ab?z,?1")
+
+    def test_uppercase_hex_token_inside_custom_charset(self):
+        line = parse_hcmask_line("?H,?1?1")
+        assert keyspace(line) == 16 * 16
+
+    def test_empty_custom_charset_still_rejected(self):
+        with pytest.raises(MaskError, match=r"custom charset \?1 is empty"):
+            parse_hcmask_line(",?1")
+
+
+class TestVeryLargeKeyspaceDescribe:
+    """describe() must not overflow on keyspaces beyond float range."""
+
+    def test_describe_does_not_overflow_on_huge_keyspace(self):
+        # ?b * 200 => 256^200 ~= 10^481, far beyond float's ~1.8e308.
+        line = parse_hcmask_line("?b" * 200)
+        ks = keyspace(line)
+        assert ks == 256**200
+        desc = describe(line)
+        assert "200 × byte" in desc
+        # digits - 1 == the exponent; 256^200 has 482 digits.
+        assert f"e+{len(str(ks)) - 1}" in desc
+        assert "(~4.4e+481)" in desc
+
+    def test_short_scientific_matches_float_formatting(self):
+        # The integer implementation must be byte-identical to the previous
+        # float-based f"{ks:.1e}" for everything a float can represent.
+        for value in (10**9 + 1, 256**6, 12_345_678_901, 999_999_999_999, 10**300):
+            assert _short_scientific(value) == f"{value:.1e}"
+
+    def test_describe_scientific_format_unchanged(self):
+        line = parse_hcmask_line("?b?b?b?b?b?b")
+        assert "(~2.8e+14)" in describe(line)

--- a/tests/test_nlmask.py
+++ b/tests/test_nlmask.py
@@ -4,6 +4,8 @@ Uses a fake OpenAI-shaped client so no real network access is required.
 """
 
 import json
+import subprocess
+import sys
 from dataclasses import dataclass
 from types import SimpleNamespace
 
@@ -19,6 +21,7 @@ from hashcat_rosetta.nlmask import (
     generate_masks,
     resolve_base_url,
 )
+from hashcat_rosetta.nlmask import _build_retry_message, _validate_items
 
 
 def _make_response(content: str) -> SimpleNamespace:
@@ -345,3 +348,125 @@ class TestModuleConstants:
         assert "?1" in SYSTEM_PROMPT
         assert "?d" in SYSTEM_PROMPT
         assert "why" in SYSTEM_PROMPT
+
+
+NON_STRING_MASK_JSON = json.dumps(
+    {"masks": [{"mask": 123, "custom_charsets": [], "why": "a number, not a mask"}]}
+)
+
+STRING_CUSTOM_CHARSETS_JSON = json.dumps(
+    {"masks": [{"mask": "?1?1", "custom_charsets": "abc", "why": "string, not an array"}]}
+)
+
+NON_STRING_CHARSET_ELEMENT_JSON = json.dumps(
+    {"masks": [{"mask": "?1?1", "custom_charsets": ["ab", 7], "why": "element is a number"}]}
+)
+
+
+class TestGenerateMasksWronglyTypedFields:
+    """Model output is untrusted: wrongly-typed fields must be validation
+    failures feeding the retry, never an uncaught TypeError/AttributeError."""
+
+    def test_validate_items_does_not_raise_on_non_string_mask(self):
+        suggestions, failures = _validate_items([{"mask": 123, "custom_charsets": [], "why": "x"}])
+        assert suggestions == []
+        assert len(failures) == 1
+        assert "'mask' must be a string" in failures[0][1]
+        assert "int" in failures[0][1]
+
+    def test_validate_items_does_not_silently_split_a_string_charset(self):
+        # A bare string used to iterate character-by-character into three
+        # single-char custom charsets, silently producing a wrong mask.
+        suggestions, failures = _validate_items(
+            [{"mask": "?1?1", "custom_charsets": "abc", "why": "x"}]
+        )
+        assert suggestions == []
+        assert len(failures) == 1
+        assert "'custom_charsets' must be an array of strings" in failures[0][1]
+
+    def test_validate_items_rejects_non_string_charset_element(self):
+        suggestions, failures = _validate_items(
+            [{"mask": "?1?1", "custom_charsets": ["ab", 7], "why": "x"}]
+        )
+        assert suggestions == []
+        assert len(failures) == 1
+        assert "custom_charsets[1] must be a string" in failures[0][1]
+
+    def test_failures_render_into_a_retry_prompt_without_raising(self):
+        _, failures = _validate_items(
+            [
+                {"mask": 123, "custom_charsets": [], "why": "x"},
+                {"mask": "?1?1", "custom_charsets": "abc", "why": "x"},
+            ]
+        )
+        message = _build_retry_message(failures)
+        assert "'mask' must be a string" in message
+        assert "'custom_charsets' must be an array of strings" in message
+
+    def test_non_string_mask_retries_then_succeeds(self):
+        completions = FakeCompletions([NON_STRING_MASK_JSON, VALID_JSON])
+        client = FakeClient(completions)
+
+        result = generate_masks("something", client=client)
+
+        assert len(completions.calls) == 2
+        assert len(result) == 1
+        assert result[0].mask == "?d?d?d?d?d?d"
+
+    def test_non_string_mask_both_calls_raises_mask_generation_error(self):
+        completions = FakeCompletions([NON_STRING_MASK_JSON, NON_STRING_MASK_JSON])
+        client = FakeClient(completions)
+
+        with pytest.raises(MaskGenerationError) as exc_info:
+            generate_masks("something", client=client)
+
+        assert len(completions.calls) == 2
+        assert "'mask' must be a string" in str(exc_info.value)
+
+    def test_string_custom_charsets_both_calls_raises_mask_generation_error(self):
+        completions = FakeCompletions([STRING_CUSTOM_CHARSETS_JSON, STRING_CUSTOM_CHARSETS_JSON])
+        client = FakeClient(completions)
+
+        with pytest.raises(MaskGenerationError) as exc_info:
+            generate_masks("something", client=client)
+
+        assert len(completions.calls) == 2
+        assert "'custom_charsets' must be an array of strings" in str(exc_info.value)
+
+    def test_non_string_charset_element_retries_then_succeeds(self):
+        completions = FakeCompletions([NON_STRING_CHARSET_ELEMENT_JSON, VALID_JSON])
+        client = FakeClient(completions)
+
+        result = generate_masks("something", client=client)
+
+        assert len(completions.calls) == 2
+        assert result[0].mask == "?d?d?d?d?d?d"
+
+
+class TestImportIsolation:
+    """nlmask is the only module importing the openai SDK, and it is loaded
+    lazily so non-LLM commands do not pay its import cost."""
+
+    def test_importing_package_does_not_import_openai(self):
+        code = (
+            "import sys; import hashcat_rosetta, hashcat_rosetta.cli; "
+            "assert 'openai' not in sys.modules, 'openai was imported eagerly'; "
+            "assert 'hashcat_rosetta.nlmask' not in sys.modules"
+        )
+        subprocess.run([sys.executable, "-c", code], check=True)
+
+    def test_lazy_attribute_access_still_works(self):
+        code = (
+            "from hashcat_rosetta import generate_masks, MaskGenerationError, MaskSuggestion; "
+            "import hashcat_rosetta; assert hashcat_rosetta.generate_masks is generate_masks; "
+            "assert 'generate_masks' in dir(hashcat_rosetta)"
+        )
+        subprocess.run([sys.executable, "-c", code], check=True)
+
+    def test_unknown_attribute_still_raises_attribute_error(self):
+        import hashcat_rosetta
+
+        with pytest.raises(AttributeError):
+            # getattr(), not attribute syntax: a literal bad attribute is a
+            # static error mypy rightly flags on a module with __all__.
+            getattr(hashcat_rosetta, "definitely_not_a_real_export")

--- a/tests/test_nlmask.py
+++ b/tests/test_nlmask.py
@@ -1,0 +1,237 @@
+"""Tests for natural-language to hcmask generation (nlmask.py).
+
+Uses a fake OpenAI-shaped client so no real network access is required.
+"""
+
+import json
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+from openai import APIConnectionError
+
+from hashcat_rosetta.mask import HcmaskLine
+from hashcat_rosetta.nlmask import (
+    MASK_SCHEMA,
+    SYSTEM_PROMPT,
+    MaskGenerationError,
+    MaskSuggestion,
+    generate_masks,
+    resolve_base_url,
+)
+
+
+def _make_response(content: str) -> SimpleNamespace:
+    """Build an object shaped like the OpenAI SDK's ChatCompletion response."""
+    message = SimpleNamespace(content=content)
+    choice = SimpleNamespace(message=message)
+    return SimpleNamespace(choices=[choice])
+
+
+@dataclass
+class _Call:
+    kwargs: dict
+
+
+class FakeCompletions:
+    """Fake `.chat.completions` implementing only `.create(...)`."""
+
+    def __init__(self, responses: list[str]):
+        # Each entry is the raw `content` string for one call, in order.
+        self._responses = list(responses)
+        self.calls: list[_Call] = []
+
+    def create(self, **kwargs):
+        self.calls.append(_Call(kwargs=kwargs))
+        if not self._responses:
+            raise AssertionError("FakeCompletions.create called more times than responses queued")
+        content = self._responses.pop(0)
+        return _make_response(content)
+
+
+class FakeErrorCompletions:
+    """Fake `.chat.completions` that always raises a connection error."""
+
+    def __init__(self, exc: Exception):
+        self._exc = exc
+        self.calls: list[_Call] = []
+
+    def create(self, **kwargs):
+        self.calls.append(_Call(kwargs=kwargs))
+        raise self._exc
+
+
+class FakeClient:
+    """Fake OpenAI client exposing `.chat.completions`."""
+
+    def __init__(self, completions):
+        self.chat = SimpleNamespace(completions=completions)
+
+
+VALID_JSON = json.dumps(
+    {
+        "masks": [
+            {"mask": "?d?d?d?d?d?d", "custom_charsets": [], "why": "six digit pin"},
+        ]
+    }
+)
+
+VALID_JSON_CUSTOM = json.dumps(
+    {
+        "masks": [
+            {"mask": "?1?1?d", "custom_charsets": ["ab"], "why": "custom prefix"},
+        ]
+    }
+)
+
+INVALID_JSON_UNKNOWN_TOKEN = json.dumps(
+    {
+        "masks": [
+            {"mask": "?z?d?d", "custom_charsets": [], "why": "bogus token"},
+        ]
+    }
+)
+
+
+class TestResolveBaseUrl:
+    """Table from clarification #1 plus env var handling."""
+
+    def test_bare_host_port(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_HOST", raising=False)
+        assert resolve_base_url("localhost:11434") == "http://localhost:11434/v1"
+
+    def test_http_scheme_no_v1(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_HOST", raising=False)
+        assert resolve_base_url("http://box:11434") == "http://box:11434/v1"
+
+    def test_https_trailing_slash(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_HOST", raising=False)
+        assert resolve_base_url("https://h/") == "https://h/v1"
+
+    def test_already_has_v1_idempotent(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_HOST", raising=False)
+        assert resolve_base_url("http://h/v1") == "http://h/v1"
+
+    def test_none_no_env_defaults(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_HOST", raising=False)
+        assert resolve_base_url(None) == "http://localhost:11434/v1"
+
+    def test_none_uses_env_var(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_HOST", "envhost:9999")
+        assert resolve_base_url(None) == "http://envhost:9999/v1"
+
+    def test_explicit_host_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_HOST", "envhost:9999")
+        assert resolve_base_url("explicit:1234") == "http://explicit:1234/v1"
+
+
+class TestGenerateMasksHappyPath:
+    def test_valid_json_first_try_no_retry(self):
+        completions = FakeCompletions([VALID_JSON])
+        client = FakeClient(completions)
+
+        result = generate_masks("six digit pin", client=client)
+
+        assert len(completions.calls) == 1
+        assert len(result) == 1
+        suggestion = result[0]
+        assert isinstance(suggestion, MaskSuggestion)
+        assert suggestion.mask == "?d?d?d?d?d?d"
+        assert suggestion.custom_charsets == []
+        assert suggestion.why == "six digit pin"
+        assert isinstance(suggestion.line, HcmaskLine)
+        assert suggestion.line.mask == "?d?d?d?d?d?d"
+
+    def test_valid_json_with_custom_charset(self):
+        completions = FakeCompletions([VALID_JSON_CUSTOM])
+        client = FakeClient(completions)
+
+        result = generate_masks("custom prefix", client=client)
+
+        assert len(completions.calls) == 1
+        assert result[0].custom_charsets == ["ab"]
+        assert result[0].line.custom == ["ab"]
+
+
+class TestGenerateMasksRetry:
+    def test_invalid_then_valid_triggers_exactly_one_retry(self):
+        completions = FakeCompletions([INVALID_JSON_UNKNOWN_TOKEN, VALID_JSON])
+        client = FakeClient(completions)
+
+        result = generate_masks("something", client=client)
+
+        assert len(completions.calls) == 2
+        assert len(result) == 1
+        assert result[0].mask == "?d?d?d?d?d?d"
+
+    def test_invalid_twice_raises(self):
+        completions = FakeCompletions([INVALID_JSON_UNKNOWN_TOKEN, INVALID_JSON_UNKNOWN_TOKEN])
+        client = FakeClient(completions)
+
+        with pytest.raises(MaskGenerationError) as exc_info:
+            generate_masks("something", client=client)
+
+        assert len(completions.calls) == 2
+        assert "?z?d?d" in str(exc_info.value)
+
+    def test_malformed_json_first_call_retries_then_succeeds(self):
+        malformed = "```json\n{not valid json"
+        completions = FakeCompletions([malformed, VALID_JSON])
+        client = FakeClient(completions)
+
+        result = generate_masks("something", client=client)
+
+        assert len(completions.calls) == 2
+        assert len(result) == 1
+        assert result[0].mask == "?d?d?d?d?d?d"
+
+    def test_malformed_json_both_calls_raises(self):
+        malformed = "not json at all"
+        completions = FakeCompletions([malformed, malformed])
+        client = FakeClient(completions)
+
+        with pytest.raises(MaskGenerationError):
+            generate_masks("something", client=client)
+
+        assert len(completions.calls) == 2
+
+    def test_json_wrapped_in_markdown_fence_parses_on_first_try(self):
+        fenced = f"```json\n{VALID_JSON}\n```"
+        completions = FakeCompletions([fenced])
+        client = FakeClient(completions)
+
+        result = generate_masks("something", client=client)
+
+        assert len(completions.calls) == 1
+        assert result[0].mask == "?d?d?d?d?d?d"
+
+
+class TestGenerateMasksConnectionError:
+    def test_connection_error_wrapped_with_base_url(self):
+        request = SimpleNamespace()
+        exc = APIConnectionError(request=request)
+        completions = FakeErrorCompletions(exc)
+        client = FakeClient(completions)
+
+        with pytest.raises(MaskGenerationError) as exc_info:
+            generate_masks("something", client=client, host="http://nowhere:9999")
+
+        assert "http://nowhere:9999/v1" in str(exc_info.value)
+
+
+class TestModuleConstants:
+    def test_mask_schema_shape(self):
+        assert MASK_SCHEMA["type"] == "object"
+        assert "masks" in MASK_SCHEMA["properties"]
+        assert MASK_SCHEMA["required"] == ["masks"]
+        assert MASK_SCHEMA["additionalProperties"] is False
+
+        item_schema = MASK_SCHEMA["properties"]["masks"]["items"]
+        assert set(item_schema["required"]) == {"mask", "custom_charsets", "why"}
+        assert item_schema["additionalProperties"] is False
+
+    def test_system_prompt_mentions_key_constraints(self):
+        assert "{n}" in SYSTEM_PROMPT
+        assert "?1" in SYSTEM_PROMPT
+        assert "?d" in SYSTEM_PROMPT
+        assert "why" in SYSTEM_PROMPT

--- a/tests/test_nlmask.py
+++ b/tests/test_nlmask.py
@@ -152,6 +152,29 @@ class TestGenerateMasksHappyPath:
         assert result[0].custom_charsets == ["ab"]
         assert result[0].line.custom == ["ab"]
 
+    def test_request_kwargs_include_model_temperature_and_response_format(self):
+        completions = FakeCompletions([VALID_JSON])
+        client = FakeClient(completions)
+
+        generate_masks("six digit pin", model="my-model", temperature=0.5, client=client)
+
+        assert len(completions.calls) == 1
+        kwargs = completions.calls[0].kwargs
+        assert kwargs["model"] == "my-model"
+        assert kwargs["temperature"] == 0.5
+        assert kwargs["response_format"]["type"] == "json_schema"
+        assert kwargs["response_format"]["json_schema"]["schema"] == MASK_SCHEMA
+        assert kwargs["response_format"]["json_schema"]["strict"] is True
+
+    def test_ollama_model_env_var_used_when_model_is_none(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_MODEL", "env-model:latest")
+        completions = FakeCompletions([VALID_JSON])
+        client = FakeClient(completions)
+
+        generate_masks("six digit pin", model=None, client=client)
+
+        assert completions.calls[0].kwargs["model"] == "env-model:latest"
+
 
 class TestGenerateMasksRetry:
     def test_invalid_then_valid_triggers_exactly_one_retry(self):
@@ -163,6 +186,23 @@ class TestGenerateMasksRetry:
         assert len(completions.calls) == 2
         assert len(result) == 1
         assert result[0].mask == "?d?d?d?d?d?d"
+
+        # Minor #7: the retry conversation must carry forward context rather
+        # than blindly re-asking - the original system+user turns, the
+        # assistant's first (invalid) response, and a new user message
+        # naming the specific failing mask line and its error.
+        first_messages = completions.calls[0].kwargs["messages"]
+        retry_messages = completions.calls[1].kwargs["messages"]
+
+        assert retry_messages[0] == first_messages[0]  # system prompt
+        assert retry_messages[1] == first_messages[1]  # original user description
+        assert retry_messages[2] == {
+            "role": "assistant",
+            "content": INVALID_JSON_UNKNOWN_TOKEN,
+        }
+        assert retry_messages[3]["role"] == "user"
+        assert "?z?d?d" in retry_messages[3]["content"]
+        assert "unknown token" in retry_messages[3]["content"]
 
     def test_invalid_twice_raises(self):
         completions = FakeCompletions([INVALID_JSON_UNKNOWN_TOKEN, INVALID_JSON_UNKNOWN_TOKEN])
@@ -204,6 +244,76 @@ class TestGenerateMasksRetry:
 
         assert len(completions.calls) == 1
         assert result[0].mask == "?d?d?d?d?d?d"
+
+
+NON_DICT_TOP_LEVEL_JSON = json.dumps([{"mask": "?d", "custom_charsets": [], "why": "x"}])
+
+NON_DICT_ITEM_JSON = json.dumps({"masks": ["?d?d"]})
+
+EMPTY_MASKS_JSON = json.dumps({"masks": []})
+
+
+class TestGenerateMasksMalformedShapes:
+    """Important #1/#2/#3: non-dict top-level JSON, non-dict items, empty masks array."""
+
+    def test_non_dict_top_level_json_retries_then_succeeds(self):
+        completions = FakeCompletions([NON_DICT_TOP_LEVEL_JSON, VALID_JSON])
+        client = FakeClient(completions)
+
+        result = generate_masks("something", client=client)
+
+        assert len(completions.calls) == 2
+        assert len(result) == 1
+        assert result[0].mask == "?d?d?d?d?d?d"
+
+    def test_non_dict_top_level_json_both_calls_raises(self):
+        completions = FakeCompletions([NON_DICT_TOP_LEVEL_JSON, NON_DICT_TOP_LEVEL_JSON])
+        client = FakeClient(completions)
+
+        with pytest.raises(MaskGenerationError):
+            generate_masks("something", client=client)
+
+        assert len(completions.calls) == 2
+
+    def test_non_dict_item_in_masks_array_retries_then_succeeds(self):
+        completions = FakeCompletions([NON_DICT_ITEM_JSON, VALID_JSON])
+        client = FakeClient(completions)
+
+        result = generate_masks("something", client=client)
+
+        assert len(completions.calls) == 2
+        assert len(result) == 1
+        assert result[0].mask == "?d?d?d?d?d?d"
+
+    def test_non_dict_item_in_masks_array_both_calls_raises(self):
+        completions = FakeCompletions([NON_DICT_ITEM_JSON, NON_DICT_ITEM_JSON])
+        client = FakeClient(completions)
+
+        with pytest.raises(MaskGenerationError) as exc_info:
+            generate_masks("something", client=client)
+
+        assert len(completions.calls) == 2
+        assert "not an object" in str(exc_info.value)
+
+    def test_empty_masks_array_retries_then_succeeds(self):
+        completions = FakeCompletions([EMPTY_MASKS_JSON, VALID_JSON])
+        client = FakeClient(completions)
+
+        result = generate_masks("something", client=client)
+
+        assert len(completions.calls) == 2
+        assert len(result) == 1
+        assert result[0].mask == "?d?d?d?d?d?d"
+
+    def test_empty_masks_array_both_calls_raises(self):
+        completions = FakeCompletions([EMPTY_MASKS_JSON, EMPTY_MASKS_JSON])
+        client = FakeClient(completions)
+
+        with pytest.raises(MaskGenerationError) as exc_info:
+            generate_masks("something", client=client)
+
+        assert len(completions.calls) == 2
+        assert "no mask suggestions" in str(exc_info.value)
 
 
 class TestGenerateMasksConnectionError:

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,38 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -146,6 +178,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -167,11 +208,21 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
 name = "hashcat-rosetta"
 version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "openai" },
 ]
 
 [package.dev-dependencies]
@@ -184,7 +235,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "click", specifier = ">=8.0.0" }]
+requires-dist = [
+    { name = "click", specifier = ">=8.0.0" },
+    { name = "openai", specifier = ">=2.52.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -193,6 +247,34 @@ dev = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-cov", specifier = ">=3.0.0" },
     { name = "ruff", specifier = ">=0.6.0" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -205,12 +287,120 @@ wheels = [
 ]
 
 [[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/d8/b959609e44012a42b1f3e5ba98ea3b33c7e41e6d4b77cd8f00fd19b1d3ad/jiter-0.16.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:c5fc4f8def331036a7b8e981b4347ebe409981edbc8308a5ea842b8c3614fa6c", size = 310082, upload-time = "2026-06-29T13:02:31.356Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3d/4d7f5667ea0e0548534ba880b84bb3d12924fd133aa83ad6c6c80fca3d76/jiter-0.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5a71d0d2014c3275043e1170bf3d4e771493cb0dcf07be54c567155f4d8ee64b", size = 315643, upload-time = "2026-06-29T13:02:33.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/83/bed2dcb5c9f3e1ccfcbc67dda48265fe7d5ad0c9cadda5fe95f6e3b87f94/jiter-0.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:741eed508c233a76313a1c7b001f8f21b82f14327e9196ae8bd29a2cc164ae84", size = 341363, upload-time = "2026-06-29T13:02:34.853Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/2f/6bb3c3dda668ebc0445689c81a2b0f26a82b10843d67ed9c9b2c3edc177f/jiter-0.16.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3fb7bc819187b56dc48aa5c833aaf92257da8e07efdb9306156667bd2eeb491c", size = 365483, upload-time = "2026-06-29T13:02:36.295Z" },
+    { url = "https://files.pythonhosted.org/packages/92/35/8a045ccb39164e70dcdae696413b661771f148b68b12b175c3a04d901937/jiter-0.16.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c9610fd25ebccb43fca584136f5c2fbb26802447eccd430dfdbab95a0fd5126", size = 461219, upload-time = "2026-06-29T13:02:38.116Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/99/22292dbbf0ed0c610cfe5ddc7f3bd67237a412f121318f865196e62a07bd/jiter-0.16.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4a1d68ff7ca1d3b5dee20a97a3decda7d5f15003823bf6d140c81f8561d3bc5c", size = 374905, upload-time = "2026-06-29T13:02:40.357Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ac/2f55ccb1f0eeafa6d89d24caf52f6f0944a59290ee199e9ade62177dca42/jiter-0.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb08c276dd02dac3a284acdd02cacc630d2e3cd6572a4b85519f35cbd133c3de", size = 348320, upload-time = "2026-06-29T13:02:41.923Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e3/7d88b9174c40064fabc07c84a9b62e6b10f5644562ec0e0a29392edbe978/jiter-0.16.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:8fc4d94713c4697347e38faf7d6ef91547c142219bdcfc7220c4870879974244", size = 356519, upload-time = "2026-06-29T13:02:43.436Z" },
+    { url = "https://files.pythonhosted.org/packages/27/57/c4a33aeef513a9d5e26e31534e0bcc752d6ea0e54c94ddb7b68bade669c2/jiter-0.16.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a0f05e229edb29e68cdd0ccb83cea13b64263416120cf943767a6fd72e6787f", size = 394204, upload-time = "2026-06-29T13:02:44.987Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/70/c6c23e76ebb3766b111bc399437bbc9f870a76e2a92e10b2a5f561d57372/jiter-0.16.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:2c842cbf374a8daf50b2c04212995bee34ca2ac2cdc29a901b4cdb072c9c4131", size = 521477, upload-time = "2026-06-29T13:02:46.724Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/d3/0001c8c0c5976af2625bb1cfb1895e8ec693b6589fe4574b8e6fc2c85501/jiter-0.16.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5ed466aee31294d7cdcd4d37dfe5c42c97bc29d9a5f00eacf24504358309cb9b", size = 552187, upload-time = "2026-06-29T13:02:48.144Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/76/311b718e07e85740e48619c0632b36f7e0b8d113984499e436452ed13a9a/jiter-0.16.0-cp310-cp310-win32.whl", hash = "sha256:b42e9ff5376819c053da25809a8d4b6fa6e473b4856ebe42e298ac958be3d7f9", size = 206513, upload-time = "2026-06-29T13:02:49.515Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7f/ac680eeb0777dc0eb7dc824800ba27880d7f6bc712e362d34ad8ee559f36/jiter-0.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:10438939205546132189c8e74a2d536a707841f3a25cd7c74ee91fe503407a26", size = 199505, upload-time = "2026-06-29T13:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/3f/fae6cc967d120ec89e31c5418a51176d8278b3087fbb384a9176754f353c/jiter-0.16.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:67fddeda1688f0cce2d2ae83ccf8a80f79936f2d2997d6cc2261f82fdb54a4d3", size = 309289, upload-time = "2026-06-29T13:02:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e3/97c6c3562c077f6247d6e6ce5c82562500b6316c0d928e97e106b7a1321a/jiter-0.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c90c0f63df322be920eda6ce622e3083d8906ba267f8220fe7873213b8b4430e", size = 315181, upload-time = "2026-06-29T13:02:53.964Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/89/d8d073f8aa2667e46c6c0873f86fe4a512bba4293cc730f626a076211a62/jiter-0.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:64c0203212098470032aabcde9356fc168f377aade3e43def61dfe17e92f2037", size = 340939, upload-time = "2026-06-29T13:02:55.412Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c9/db4fda3ed73fb864139305e935e5b8b38a5a24692a5a9dd356c22f1b9c8d/jiter-0.16.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12288303c9844e61e1651d02a9a6f6633e47d39f897d6991d1427161ce6b746e", size = 364932, upload-time = "2026-06-29T13:02:57.28Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/74/52b5e86241057f52ddd7c9a580f90effb51f9d06239f6fc612279b91a838/jiter-0.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cf109d010b4b05a105afb3d43be36a21322d345ad3111e13d15f680afef0e5b", size = 461132, upload-time = "2026-06-29T13:02:58.994Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/87/544a700f7447c1f31c5d7833821a4daa5683165c2d5a094fbf5b5800c3dc/jiter-0.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62c1b7fe1f77925acf5af68b6140b8810fa87dfd4dc0a9c8568ec2fa2a10429c", size = 374857, upload-time = "2026-06-29T13:03:00.455Z" },
+    { url = "https://files.pythonhosted.org/packages/40/cd/0fcc3f7d39183674d5bfa9ec640faaeb506c60be7c8f94625dfba366e37c/jiter-0.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8597d23c87f59294f83bcb6229b9ed1fccee13dbba967b46930d2f1759466fee", size = 347053, upload-time = "2026-06-29T13:03:02.045Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ae/c7e64e7932ad597fa395b61440b249ada6366716e25c6e08dd2afbd021e6/jiter-0.16.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:3126a5dbad56401989ac769aca0cb56005bfb3e2366eea0ca99d1a91c3c1ee03", size = 356153, upload-time = "2026-06-29T13:03:03.706Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/1c/1c719044f14da814e1a060191ab19b96f3e99207bc5b4bfc6d6be34b3f80/jiter-0.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c4b4717bdb35ae456f831a6b08d01880fff399887a6bbc526a583a406e484eea", size = 393956, upload-time = "2026-06-29T13:03:05.165Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/dc/7b2f303a2847207e265503853a2d964a55354cffd62a5f2936c155486798/jiter-0.16.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:adff21bc78edfe086c15eb495b900306076de378dc2337c132401fc39bd79c91", size = 521081, upload-time = "2026-06-29T13:03:06.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/5f/501cf6e1e09caeb420195179ffc6f62aca603f1220ec53fd80d0d70b3e56/jiter-0.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:dab907db06fc593645e73109acf4581ba5b548897d28b9348dc41ddc8343b2d3", size = 552085, upload-time = "2026-06-29T13:03:08.339Z" },
+    { url = "https://files.pythonhosted.org/packages/79/54/aa5be86520113b79455c3877f3d1f07a348098df4083ba3688e9537e52dd/jiter-0.16.0-cp311-cp311-win32.whl", hash = "sha256:560b2cf3fb03240cd34f27409a238547488708f05b7c3924f571a60422251ec7", size = 206755, upload-time = "2026-06-29T13:03:09.653Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ec/2feb893eb330bd69b413866f4d5daada33c3962f1c6f270c91ca2d87fdf9/jiter-0.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:e431cfc9caf44c1d5459ff77d4e64cbf85fddb6a35dad836a15c6a9ec23087c1", size = 199155, upload-time = "2026-06-29T13:03:10.979Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9c/ca040d94415048a3666fc237774df8151c96f8d2b661cbe3b184acc95876/jiter-0.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:2a8e9e39cf083016137aa5cadafe3188adc2ba6ba1fbf1e5d18889ad3e9ad056", size = 194403, upload-time = "2026-06-29T13:03:12.341Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a", size = 306943, upload-time = "2026-06-29T13:03:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9", size = 307779, upload-time = "2026-06-29T13:03:15.418Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/59bd309cab4460c54cf1079f3eb7fe7af6a4c895c5c957a53378693bad2b/jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72", size = 335826, upload-time = "2026-06-29T13:03:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/f5ef7b65f0df47afa16596969defb281ebb86e96df346d62be6fd853d620/jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e", size = 362573, upload-time = "2026-06-29T13:03:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0b/ace4354da061ee38844a0c27dc2c21eecd27aea119e8da324bea987522d0/jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290", size = 457979, upload-time = "2026-06-29T13:03:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/55/40/c0253d3772eb9dcd8e6606ee9b2d53ec8e5b814589c47f140aa585f21eaa/jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01", size = 372302, upload-time = "2026-06-29T13:03:21.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48", size = 343805, upload-time = "2026-06-29T13:03:23.384Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/e196888a05befdda7dbe299b722d56f2f6eec65402bc34c0a3306d595feb/jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9", size = 351107, upload-time = "2026-06-29T13:03:24.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/74/4cd9e0fca65232136400354b630fbfcd2de634e22ccbb96567725981b548/jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5", size = 388441, upload-time = "2026-06-29T13:03:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8c/554691e48bc711299c0a293dd8a6179e24b2d66a54dc295421fcf64569c0/jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730", size = 516354, upload-time = "2026-06-29T13:03:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cb/01e9d69dc2cc6759d4f91e230b34489c4fdb2518992650633f9e20bece89/jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f", size = 547880, upload-time = "2026-06-29T13:03:29.534Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/2953195f1c6ad00f49fa67e13df7e60acb3dd4f387101bc15abccddd905e/jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274", size = 203473, upload-time = "2026-06-29T13:03:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/05/2909a8b10699a4d560f8c502b6b2c5f3991b682b1922c1eedda242b225bd/jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7", size = 196905, upload-time = "2026-06-29T13:03:32.472Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a9/6b82bb1c8d7790d602489b967b982a909e5d092875a6c2ade96444c8dfc5/jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331", size = 190618, upload-time = "2026-06-29T13:03:34.672Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d3/8e278946d43eeca2585b4dd0834a887cd71136329b837f3a16ed86a8b4b0/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:850ccb1d7eedb4200f4014b1c0e8a577de114fc3cd88faad646dcc9bc4bb12ad", size = 304518, upload-time = "2026-06-29T13:05:00.172Z" },
+    { url = "https://files.pythonhosted.org/packages/72/43/28d4ef495028bf0506a413d4db3f4eb3e7288a382e0f065f306a17bbeb5e/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:e34e97bda77eb63242a410243c071e28ac7e0d8c0948c5ee658498690a4b2f2f", size = 310207, upload-time = "2026-06-29T13:05:02.123Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ca/c366b1012da1d640de975d9683acd44e4d150d9068845d0ca2610435253f/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7dc85ea77d4abbae8bad0d3538678aedee75bceec4e2f6c8dfb1c74772e5aa5", size = 342771, upload-time = "2026-06-29T13:05:03.55Z" },
+    { url = "https://files.pythonhosted.org/packages/16/52/50cc4056fc1ae02e7154704e7ecc89df0afb8300222cfe8a52d3f67e4730/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17ca7fae79f6d99cd9a042b75f917eaada7b895cfc7dd2ee3a16089dcaec7a85", size = 346468, upload-time = "2026-06-29T13:05:05.452Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ab/664fd8c4be028b2bedd3d2ff08769c4ede23d0dbc87a77c62384a0515b5d/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127", size = 303106, upload-time = "2026-06-29T13:05:07.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
 ]
 
 [[package]]
@@ -351,6 +541,25 @@ wheels = [
 ]
 
 [[package]]
+name = "openai"
+version = "2.52.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/5a/c45fa035cd72c70ebe67c6e079e3adf871492382634f69e3dff62c43597d/openai-2.52.0.tar.gz", hash = "sha256:7c736d592f81471ce1f734838390983c4d8c8aecff23dcd36e600a58e5032d9c", size = 1098876, upload-time = "2026-07-31T15:13:03.228Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/ac/ceb40c995df49533ad4dcff6c37f0d85cf14446a212363fc9d2f927e60b4/openai-2.52.0-py3-none-any.whl", hash = "sha256:f97e231d9a8fa69ab55897df1080f02d99913fb0a30e3ee56ea16a1eb6c2d434", size = 1659569, upload-time = "2026-07-31T15:13:01.145Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -400,6 +609,137 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/08/f1ba952f1c8ae5581c70fa9c6da89f247b83e3dd8c09c035d5d7931fc23d/pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4", size = 2113146, upload-time = "2026-05-06T13:37:36.537Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c6/65f646c7ff09bd257f660434adb45c4dfcbbcebcc030562fecf6f5bf887d/pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5", size = 1949769, upload-time = "2026-05-06T13:37:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ba/bfb1d928fd5b49e1258935ff104ae356e9fd89384a55bf9f847e9193ad40/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb63e0198ca18aad131c089b9204c23079c3afa95487e561f4c522d519e55aba", size = 1974958, upload-time = "2026-05-06T13:37:28.611Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/74/76223bfb117b64af743c9b6670d1364516f5c0604f96b48f3272f6af6cc6/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f47286a97f0bc9b8859519809077b91b2cefe4ae47fcbf5e466a009c1c5d742b", size = 2042118, upload-time = "2026-05-06T13:36:55.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7b/848732968bc8f48f3187542f08358b9d842db564147b256669426ebb1652/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:905a0ed8ea6f2d61c1738835f99b699348d7857379083e5fc497fa0c967a407c", size = 2222876, upload-time = "2026-05-06T13:38:25.455Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2f/e90b63ee2e14bd8d3db8f705a6d75d64e6ee1b7c2c8833747ce706e1e0ce/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea793e075b70290d89d8142074262885d3f7da19634845135751bd6344f73b50", size = 2286703, upload-time = "2026-05-06T13:37:53.304Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/1e/acc4d70f88a0a277e4a1fa77ebb985ceabaf900430f875bf9338e11c9420/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:395aebd9183f9d112f569aeb5b2214d1a10a33bec8456447f7fbdfa51d38d4cd", size = 2092042, upload-time = "2026-05-06T13:38:46.981Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/da/0a422b57bf8504102bf3c4ccea9c41bab5a5cee6a54650acf8faf67f5a24/pydantic_core-2.46.4-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:b078afbc25f3a1436c7a1d2cd3e322497ee99615ba97c563566fdf46aff1ee01", size = 2117231, upload-time = "2026-05-06T13:39:23.146Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2a/2ac13c3af305843e23c5078c53d135656b3f05a2fd78cb7bbbb12e97b473/pydantic_core-2.46.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f747929cf940cddb5b3668a390056ddd5ba2e5010615ea2dcf4f9c4f3ab8791d", size = 2168388, upload-time = "2026-05-06T13:40:08.06Z" },
+    { url = "https://files.pythonhosted.org/packages/72/04/2beacf7e1607e93eefe4aed1b4709f079b905fb77530179d4f7c71745f22/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:daa27d92c36f24388fe3ad306b174781c747627f134452e4f128ea00ce1fe8c4", size = 2184769, upload-time = "2026-05-06T13:38:13.901Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/29/d2b9fd9f539133548eaf622c06a4ce176cb46ac59f32d0359c4abc0de047/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:19e51f073cd3df251856a8a4189fbdf1de4012c3ebacfb1884f94f1eb406079f", size = 2319312, upload-time = "2026-05-06T13:39:08.24Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/0f7a5b85fec6075bea96e3ef9187de38fccced0de92c1e7feda8d5cc7bb9/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c1747f85cee84c26985853c6f3d9bd3e75da5212912443fa111c113b9c246f39", size = 2361817, upload-time = "2026-05-06T13:38:43.2Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a4/73363fec545fd3ec025490bdda2743c56d0dd5b6266b1a53bbe9e4265375/pydantic_core-2.46.4-cp310-cp310-win32.whl", hash = "sha256:2f84c03c8607173d16b5a854ec68a2f9079ae03237a54fb506d13af47e1d018d", size = 1987085, upload-time = "2026-05-06T13:39:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/01/aa/62f082da2c91fac1c234bc9ee0066257ce83f0604abd72e4c9d5991f2d84/pydantic_core-2.46.4-cp310-cp310-win_amd64.whl", hash = "sha256:8358a950c8909158e3df31538a7e4edc2d7265a7c54b47f0864d9e5bae9dcebf", size = 2074311, upload-time = "2026-05-06T13:39:59.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
 ]
 
 [[package]]
@@ -546,6 +886,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -600,12 +949,36 @@ wheels = [
 ]
 
 [[package]]
+name = "tqdm"
+version = "4.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds a `--mask` flag that turns an English description (e.g. "The word 'Summer' followed by six digits.") into one or more validated hashcat mask lines, using a local Ollama server via the OpenAI-compatible API (`OLLAMA_HOST`/`OLLAMA_MODEL`, overridable via `--ollama-host`/`--model`).
- New `hashcat_rosetta/mask.py`: deterministic hcmask grammar parser/validator/keyspace/describe, with correct custom-charset token expansion (`?l`/`?d`/etc. inside `?1`-`?4` definitions), backward charset references, and character deduplication — all verified against the real hashcat binary.
- New `hashcat_rosetta/nlmask.py`: the only module that imports `openai`; validates every LLM-suggested line before accepting it, with one corrective retry then a hard failure — never silently drops a bad mask.
- `-o`/`--mask-out` writes a canonical `.hcmask` file; `openai` import is lazy so non-mask commands (`--explain`, etc.) see no startup cost regression.

## Test plan
- [x] `uv run pytest -q` — 907 passed
- [x] `uv run ruff check`/`ruff format --check`/`mypy hashcat_rosetta/` — clean
- [x] End-to-end against live Ollama + real hashcat binary: generated masks match `hashcat --stdout`/keyspace exactly, including custom-charset expansion, dedup, and backward references
- [x] Full subagent-driven-development cycle: 4 tasks, each independently reviewed and fix-looped clean, plus a final whole-branch review (1 Critical + 6 Important + 2 Minor findings) fixed in one wave and independently re-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)